### PR TITLE
Remove boilerplate

### DIFF
--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -23,7 +23,7 @@ import Terminology(Call, Direction, Vulnerability)
 
 
 data Situation =
-    Situation String Direction Vulnerability Bidding DealerProg Call Commentary
+    Situation String Bidding DealerProg Call Commentary Vulnerability Direction
 data SituationInstance = SituationInstance Bidding Call Commentary Deal String
 
 
@@ -31,9 +31,9 @@ sitRef :: Situation -> String
 sitRef (Situation r _ _ _ _ _ _) = r
 
 
-situation :: String -> Direction -> Vulnerability -> Action -> Call ->
-    Commentary -> Situation
-situation r d v a c s = Situation r d v bidding deal c s
+situation :: String -> Action -> Call -> Commentary -> Vulnerability ->
+    Direction -> Situation
+situation r a c s v d = Situation r bidding deal c s v d
   where
     (bidding, deal) = finish d a
 
@@ -48,7 +48,7 @@ instance Showable SituationInstance where
 -- thing here?
 instantiate :: String -> Situation ->
         State StdGen (IO (Maybe SituationInstance))
-instantiate reference (Situation _ dn v b dl c s) = do
+instantiate reference (Situation _ b dl c s v dn) = do
     n <- use next
     let instantiate' :: IO (Maybe SituationInstance)
         instantiate' = do

--- a/src/SituationHelpers.hs
+++ b/src/SituationHelpers.hs
@@ -1,13 +1,17 @@
 module SituationHelpers (
   anyVulnerability
 , anyVulDlr
+, wrapVulDlr
+, stdWrap
 ) where
+
+import System.Random(StdGen)
 
 import Auction(Action)
 import Output(Commentary)
 import Situation(situation, Situation)
 import Topic(base, (<~), wrap, Situations)
-import Terminology(allDirections, allVulnerabilities, Call)
+import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities, Call)
 
 
 anyVulnerability :: Situation -> Situation
@@ -18,3 +22,15 @@ anyVulDlr debug action call commentary = let
     helper dir vul = situation debug dir vul action call commentary
   in
     wrap $ base helper <~ allDirections <~ allVulnerabilities
+
+
+-- Used for taking a situation that has already had some options applied to it,
+-- and giving it the options of any vulnerability and dealer
+wrapVulDlr :: (StdGen -> Vulnerability -> Direction -> Situation) -> Situations
+wrapVulDlr sit = wrap $ sit <~ allVulnerabilities <~ allDirections
+
+
+-- Used for making Situations where the only parameterization is the
+-- vulnerability and dealer.
+stdWrap :: (Vulnerability -> Direction -> Situation) -> Situations
+stdWrap = wrapVulDlr . base

--- a/src/SituationHelpers.hs
+++ b/src/SituationHelpers.hs
@@ -1,27 +1,13 @@
 module SituationHelpers (
-  anyVulnerability
-, anyVulDlr
-, wrapVulDlr
+  wrapVulDlr
 , stdWrap
 ) where
 
 import System.Random(StdGen)
 
-import Auction(Action)
-import Output(Commentary)
-import Situation(situation, Situation)
+import Situation(Situation)
 import Topic(base, (<~), wrap, Situations)
-import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities, Call)
-
-
-anyVulnerability :: Situation -> Situation
-anyVulnerability = error "TODO later"
-
-anyVulDlr :: String -> Action -> Call -> Commentary -> Situations
-anyVulDlr debug action call commentary = let
-    helper dir vul = situation debug dir vul action call commentary
-  in
-    wrap $ base helper <~ allDirections <~ allVulnerabilities
+import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities)
 
 
 -- Used for taking a situation that has already had some options applied to it,

--- a/src/Topics/JacobyTransfers.hs
+++ b/src/Topics/JacobyTransfers.hs
@@ -5,6 +5,7 @@ import Topic(Topic(..), Situations, base, (<~), wrap)
 import Auction(forbid, makeCall, makePass, pointRange, suitLength,
                minSuitLength, Action, balancedHand, constrain)
 import Situation(situation)
+import SituationHelpers(stdWrap, wrapVulDlr)
 import qualified Terminology as T
 import qualified CommonBids as B
 
@@ -86,7 +87,7 @@ setUpCompletion suit = do
 
 initiateTransferWeak :: Situations
 initiateTransferWeak = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpTransfer suit
             pointRange 0 7
@@ -99,14 +100,14 @@ initiateTransferWeak = let
            \ into the suit, then pass and leave partner at the 2 level."
         bid = T.Bid 2 $ transferSuit suit
       in
-        situation "InitWeak" dealer vul action bid explanation
+        situation "InitWeak" action bid explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.majorSuits <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 initiateTransferBInv :: Situations
 initiateTransferBInv = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpTransfer suit
             pointRange 8 9
@@ -122,14 +123,14 @@ initiateTransferBInv = let
            \ playing in partscore with a minimum hand and game with a maximum."
         bid = T.Bid 2 $ transferSuit suit
       in
-        situation "InitBInv" dealer vul action bid explanation
+        situation "InitBInv" action bid explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.majorSuits <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 initiateTransferBGf :: Situations
 initiateTransferBGf = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpTransfer suit
             pointRange 10 14
@@ -146,14 +147,14 @@ initiateTransferBGf = let
            \ belong in game but not slam."
         bid = T.Bid 2 $ transferSuit suit
       in
-        situation "InitBGF" dealer vul action bid explanation
+        situation "InitBGF" action bid explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.majorSuits <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 completeTransfer :: Situations
 completeTransfer = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpCompletion suit
             minSuitLength suit 3
@@ -164,14 +165,14 @@ completeTransfer = let
           \ but wants you to be declarer so your stronger hand stays hidden."
         bid = T.Bid 2 suit
       in
-        situation "Complete" dealer vul action bid explanation
+        situation "Complete" action bid explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.majorSuits <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 completeTransferShort :: Situations
 completeTransferShort = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpCompletion suit
             suitLength suit 2
@@ -187,43 +188,40 @@ completeTransferShort = let
           \ another bid to give you options of where to play."
         bid = T.Bid 2 suit
       in
-        situation "Short" dealer vul action bid explanation
+        situation "Short" action bid explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.majorSuits <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 majors55inv :: Situations
 majors55inv = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.North
-            B.strong1NT
-            B.cannotPreempt >> makePass
-            suitLength T.Hearts 5
-            suitLength T.Spades 5
-            pointRange 7 9
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". With 5" ++
-            output fmt NDash ++ "5 in\
-          \ the majors and invitational strength, first make a Jacoby transfer\
-          \ into hearts, and then bid " ++ output fmt (T.Bid 2 T.Spades) ++ "\
-          \ afterwards. Partner will then have the options of passing " ++
-            output fmt (T.Bid 2 T.Spades) ++ " with a minimum hand and a spade\
-          \ fit, bidding " ++ output fmt (T.Bid 3 T.Hearts) ++ " with a minimum\
-          \ hand and no spade fit (in which case a heart fit is guaranteed), or\
-          \ bidding one of the majors at the 4 level with a maximum. This\
-          \ wrong-sides the contract when the " ++ output fmt oneNT ++ " bidder\
-          \ has a doubleton heart."
-        bid = T.Bid 2 T.Diamonds
-      in
-        situation "55Inv" dealer vul action bid explanation
+    action = do
+        B.setOpener T.North
+        B.strong1NT
+        B.cannotPreempt >> makePass
+        suitLength T.Hearts 5
+        suitLength T.Spades 5
+        pointRange 7 9
+    explanation fmt =
+        "Partner has opened a strong " ++ output fmt oneNT ++ ". With 5" ++
+        output fmt NDash ++ "5 in\
+      \ the majors and invitational strength, first make a Jacoby transfer\
+      \ into hearts, and then bid " ++ output fmt (T.Bid 2 T.Spades) ++ "\
+      \ afterwards. Partner will then have the options of passing " ++
+        output fmt (T.Bid 2 T.Spades) ++ " with a minimum hand and a spade\
+      \ fit, bidding " ++ output fmt (T.Bid 3 T.Hearts) ++ " with a minimum\
+      \ hand and no spade fit (in which case a heart fit is guaranteed), or\
+      \ bidding one of the majors at the 4 level with a maximum. This\
+      \ wrong-sides the contract when the " ++ output fmt oneNT ++ " bidder\
+      \ has a doubleton heart."
+    bid = T.Bid 2 T.Diamonds
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "55Inv" action bid explanation
 
 
 majors55gf :: Situations
 majors55gf = let
-    sit dealer vul = let
+    sit = let
         action = do
             B.setOpener T.North
             B.strong1NT
@@ -242,12 +240,12 @@ majors55gf = let
             \ bidder has a doubleton spade."
         bid = T.Bid 2 T.Hearts
       in
-        situation "55GF" dealer vul action bid explanation
+        situation "55GF" action bid explanation
   in
     -- Note that with 5-5 and game-going strength, you would have opened the
     -- bidding if you had a chance. So, you must not have had a chance to bid
     -- before your partner.
-    wrap $ base sit <~ [T.West, T.North] <~ T.allVulnerabilities
+    wrap $ base sit <~ T.allVulnerabilities <~ [T.West, T.North]
 
 
 topic :: Topic

--- a/src/Topics/MinorTransfersScott.hs
+++ b/src/Topics/MinorTransfersScott.hs
@@ -80,7 +80,7 @@ setUpSuperacceptCompletion suit = do
 
 initiateTransfer :: Situations
 initiateTransfer = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpTransfer suit
         explanation fmt =
@@ -90,14 +90,14 @@ initiateTransfer = let
            \ stronger hand stays hidden."
         bid = T.Bid 2 $ transferSuit suit
       in
-        situation "Init" dealer vul action bid explanation
+        situation "Init" action bid explanation
   in
-    wrap $ base sit <~ [T.West, T.North] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.West, T.North]
 
 
 completeTransfer :: Situations
 completeTransfer = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpCompletion suit
             forbid (canSuperaccept suit)
@@ -109,14 +109,14 @@ completeTransfer = let
           \ suit."
         bid = T.Bid 3 suit
       in
-        situation "Complete" dealer vul action bid explanation
+        situation "Complete" action bid explanation
   in
-    wrap $ base sit <~ [T.East, T.South] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
 
 
 superacceptTransfer :: Situations
 superacceptTransfer = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpCompletion suit
             canSuperaccept suit
@@ -131,14 +131,14 @@ superacceptTransfer = let
             output fmt (T.Bid 3 suit) ++ " contract if it won't."
         bid = superacceptBid suit
       in
-        situation "SupAcc" dealer vul action bid explanation
+        situation "SupAcc" action bid explanation
   in
-    wrap $ base sit <~ [T.East, T.South] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
 
 
 completeSuperacceptAKQ :: Situations
 completeSuperacceptAKQ = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpSuperacceptCompletion suit
             hasTopN suit 3 2
@@ -153,14 +153,14 @@ completeSuperacceptAKQ = let
           \ despite your lack of points."
         bid = T.Bid 3 T.Notrump
       in
-        situation "3NTAKQ" dealer vul action bid explanation
+        situation "3NTAKQ" action bid explanation
   in
-    wrap $ base sit <~ [T.North, T.West] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 completeSuperacceptKQJ10 :: Situations
 completeSuperacceptKQJ10 = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpSuperacceptCompletion suit
             forbid (hasTopN suit 3 2)
@@ -177,14 +177,14 @@ completeSuperacceptKQJ10 = let
           \ be makable, despite your lack of points."
         bid = T.Bid 3 T.Notrump
       in
-        situation "3NTKQJ" dealer vul action bid explanation
+        situation "3NTKQJ" action bid explanation
   in
-    wrap $ base sit <~ [T.North, T.West] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 completeSuperaccept10CardFit :: Situations
 completeSuperaccept10CardFit = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpSuperacceptCompletion suit
             hasTopN suit 2 1
@@ -199,14 +199,14 @@ completeSuperaccept10CardFit = let
           \ game."
         bid = T.Bid 3 T.Notrump
       in
-        situation "3NT10Fit" dealer vul action bid explanation
+        situation "3NT10Fit" action bid explanation
   in
-    wrap $ base sit <~ [T.North, T.West] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 failSuperaccept :: Situations
 failSuperaccept = let
-    sit dealer suit vul = let
+    sit suit = let
         action = do
             setUpSuperacceptCompletion suit
             forbid (hasTopN suit 2 1)
@@ -222,14 +222,14 @@ failSuperaccept = let
           \ the contract."
         bid = T.Bid 3 suit
       in
-        situation "SupFail" dealer vul action bid explanation
+        situation "SupFail" action bid explanation
   in
-    wrap $ base sit <~ [T.North, T.West] <~ T.minorSuits <~ T.allVulnerabilities
+    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 notrumpInvite :: Situations
 notrumpInvite = let
-    sit dealer vul = let
+    sit = let
         action = do
             B.setOpener T.North
             B.strong1NT
@@ -251,9 +251,9 @@ notrumpInvite = let
           \ transfer."
         bid = T.Bid 2 T.Clubs
       in
-        situation "NTInv" dealer vul action bid explanation
+        situation "NTInv" action bid explanation
   in
-    wrap $ base sit <~ [T.North, T.West] <~ T.allVulnerabilities
+    wrap $ base sit <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 topic :: Topic

--- a/src/Topics/PrecisionOpeners.hs
+++ b/src/Topics/PrecisionOpeners.hs
@@ -5,6 +5,7 @@ import Topic(Topic(..), base, (<~), wrap, Situations)
 import Auction(forbid, pointRange, suitLength, minSuitLength, {-maxSuitLength,-}
                Action, balancedHand, constrain)
 import Situation(situation)
+import SituationHelpers(stdWrap, wrapVulDlr)
 import qualified Terminology as T
 import qualified CommonBids as B
 
@@ -68,40 +69,34 @@ oneDiamondOpener = do
 
 oneClub :: Situations
 oneClub = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            oneClubOpener
-        explanation fmt =
-            "With 16 or more points, open a strong " ++
-            output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of the\
-          \ Precision Club system."
-      in
-        situation "1C" dealer vul action (T.Bid 1 T.Clubs) explanation
+    action = do
+        B.setOpener T.South
+        oneClubOpener
+    explanation fmt =
+        "With 16 or more points, open a strong " ++
+        output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of the\
+      \ Precision Club system."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1C" action (T.Bid 1 T.Clubs) explanation
 
 
 oneDiamond :: Situations
 oneDiamond = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            oneDiamondOpener
-        explanation fmt =
-            "With opening strength but not enough for a strong " ++
-            output fmt (T.Bid 1 T.Clubs) ++ " and no 5-card major or 6-card\
-          \ club suit, open a diamond. Partner will announce that it ``could\
-          \ be short.''"
-      in
-        situation "1D" dealer vul action (T.Bid 1 T.Diamonds) explanation
+    action = do
+        B.setOpener T.South
+        oneDiamondOpener
+    explanation fmt =
+        "With opening strength but not enough for a strong " ++
+        output fmt (T.Bid 1 T.Clubs) ++ " and no 5-card major or 6-card\
+      \ club suit, open a diamond. Partner will announce that it ``could\
+      \ be short.''"
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
 
 
 oneMajor :: Situations
 oneMajor = let
-    sit dealer vul suit = let
+    sit suit = let
         action = do
             B.setOpener T.South
             oneMajorOpener suit
@@ -110,29 +105,26 @@ oneMajor = let
             "With opening strength but not enough for a strong " ++
             output fmt (T.Bid 1 T.Clubs) ++ " open a 5-card major suit."
       in
-        situation "1M" dealer vul action (T.Bid 1 suit) explanation
+        situation "1M" action (T.Bid 1 suit) explanation
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities <~ T.majorSuits
+    wrapVulDlr $ base sit <~ T.majorSuits
 
 
 {-
 twoClubs6 :: Situations
 twoClubs6 = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            pointRange 10 15
-            minSuitLength T.Clubs 6
-            maxSuitLength T.Spades 4
-            maxSuitLength T.Hearts 4
-        explanation fmt =
-            "With opening strength but not enough for a strong " ++
-            output fmt (T.Bid 1 T.Clubs) ++ " open a 6-card club suit at the\
-          \ two level."
-      in
-        situation "2C" dealer vul action (T.Bid 2 T.Clubs) explanation
+    action = do
+        B.setOpener T.South
+        pointRange 10 15
+        minSuitLength T.Clubs 6
+        maxSuitLength T.Spades 4
+        maxSuitLength T.Hearts 4
+    explanation fmt =
+        "With opening strength but not enough for a strong " ++
+        output fmt (T.Bid 1 T.Clubs) ++ " open a 6-card club suit at the\
+      \ two level."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "2C" action (T.Bid 2 T.Clubs) explanation
 -}
 
 

--- a/src/Topics/StandardOpeners.hs
+++ b/src/Topics/StandardOpeners.hs
@@ -5,6 +5,7 @@ import Topic(Topic(..), base, (<~), wrap, Situations)
 import Auction(forbid, {-pointRange,-} suitLength, minSuitLength, maxSuitLength,
                withholdBid, {-Action, balancedHand, constrain-})
 import Situation(situation)
+import SituationHelpers(stdWrap, wrapVulDlr)
 import qualified Terminology as T
 import qualified CommonBids as B
 import qualified StandardOpenings as SO
@@ -17,165 +18,138 @@ import qualified StandardOpenings as SO
 
 oneNotrump :: Situations
 oneNotrump = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            withholdBid SO.b1n
-        explanation fmt =
-            "With 15 to 17 HCP and a balanced hand, open a strong " ++
-            output fmt (T.Bid 1 T.Notrump) ++ ". No need to plan a second bid;\
-          \ partner is now captain of the auction and will take over for you."
-      in
-        situation "1N" dealer vul action (T.Bid 1 T.Notrump) explanation
+    action = do
+        B.setOpener T.South
+        withholdBid SO.b1n
+    explanation fmt =
+        "With 15 to 17 HCP and a balanced hand, open a strong " ++
+        output fmt (T.Bid 1 T.Notrump) ++ ". No need to plan a second bid;\
+      \ partner is now captain of the auction and will take over for you."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1N" action (T.Bid 1 T.Notrump) explanation
 
 
 twoNotrump :: Situations
 twoNotrump = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            withholdBid SO.b2n
-        explanation fmt =
-            "With 20 to 21 HCP and a balanced hand, open " ++
-            output fmt (T.Bid 2 T.Notrump) ++ ". No need to plan a second bid;\
-          \ partner is now captain of the auction and will take over for you."
-      in
-        situation "2N" dealer vul action (T.Bid 2 T.Notrump) explanation
+    action = do
+        B.setOpener T.South
+        withholdBid SO.b2n
+    explanation fmt =
+        "With 20 to 21 HCP and a balanced hand, open " ++
+        output fmt (T.Bid 2 T.Notrump) ++ ". No need to plan a second bid;\
+      \ partner is now captain of the auction and will take over for you."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "2N" action (T.Bid 2 T.Notrump) explanation
 
 
 oneSpade :: Situations
 oneSpade = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-            withholdBid SO.b1s
-        explanation fmt =
-            "With a 5-card spade suit and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Spades) ++ "."
-      in
-        situation "1S" dealer vul action (T.Bid 1 T.Spades) explanation
+    action = do
+        B.setOpener T.South
+        forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
+        withholdBid SO.b1s
+    explanation fmt =
+        "With a 5-card spade suit and a hand unsuitable for opening \
+      \ notrump, open " ++ output fmt (T.Bid 1 T.Spades) ++ "."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1S" action (T.Bid 1 T.Spades) explanation
 
 
 oneHeart :: Situations
 oneHeart = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-            withholdBid SO.b1h
-        explanation fmt =
-            "With a 5-card heart suit and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Hearts) ++ "."
-      in
-        situation "1H" dealer vul action (T.Bid 1 T.Hearts) explanation
+    action = do
+        B.setOpener T.South
+        forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
+        withholdBid SO.b1h
+    explanation fmt =
+        "With a 5-card heart suit and a hand unsuitable for opening \
+      \ notrump, open " ++ output fmt (T.Bid 1 T.Hearts) ++ "."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1H" action (T.Bid 1 T.Hearts) explanation
 
 
 bothMajorsReverse :: Situations
 bothMajorsReverse = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            minSuitLength T.Spades 5
-            minSuitLength T.Hearts 5
-            withholdBid SO.b1h
-        explanation fmt =
-            "With at least 5-5 in the majors and enough strength to reverse,\
-          \ open " ++ output fmt (T.Bid 1 T.Hearts) ++ ", planning to rebid " ++
-            output fmt (T.Bid 2 T.Spades) ++ " next turn."
-      in
-        situation "MajRev" dealer vul action (T.Bid 1 T.Hearts) explanation
+    action = do
+        B.setOpener T.South
+        minSuitLength T.Spades 5
+        minSuitLength T.Hearts 5
+        withholdBid SO.b1h
+    explanation fmt =
+        "With at least 5-5 in the majors and enough strength to reverse,\
+      \ open " ++ output fmt (T.Bid 1 T.Hearts) ++ ", planning to rebid " ++
+        output fmt (T.Bid 2 T.Spades) ++ " next turn."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "MajRev" action (T.Bid 1 T.Hearts) explanation
 
 
 bothMajorsNoReverse :: Situations
 bothMajorsNoReverse = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            minSuitLength T.Spades 5
-            minSuitLength T.Hearts 5
-            withholdBid SO.b1s
-        explanation fmt =
-            "With at least 5-5 in the majors and not enough strength to\
-          \ reverse, open " ++ output fmt (T.Bid 1 T.Spades) ++ ", planning\
-          \ to rebid " ++ output fmt (T.Bid 2 T.Hearts) ++ " next turn."
-      in
-        situation "MajNoRev" dealer vul action (T.Bid 1 T.Spades) explanation
+    action = do
+        B.setOpener T.South
+        minSuitLength T.Spades 5
+        minSuitLength T.Hearts 5
+        withholdBid SO.b1s
+    explanation fmt =
+        "With at least 5-5 in the majors and not enough strength to\
+      \ reverse, open " ++ output fmt (T.Bid 1 T.Spades) ++ ", planning\
+      \ to rebid " ++ output fmt (T.Bid 2 T.Hearts) ++ " next turn."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "MajNoRev" action (T.Bid 1 T.Spades) explanation
 
 
 oneDiamond :: Situations
 oneDiamond = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            maxSuitLength T.Clubs 3
-            minSuitLength T.Diamonds 4
-            withholdBid SO.b1d
-        explanation fmt =
-            "With no 5-card major and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
-          \ diamonds is your only minor."
-      in
-        situation "1D1Suit" dealer vul action (T.Bid 1 T.Diamonds) explanation
+    action = do
+        B.setOpener T.South
+        maxSuitLength T.Clubs 3
+        minSuitLength T.Diamonds 4
+        withholdBid SO.b1d
+    explanation fmt =
+        "With no 5-card major and a hand unsuitable for opening \
+      \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
+      \ diamonds is your only minor."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1D1Suit" action (T.Bid 1 T.Diamonds) explanation
 
 
 oneDiamond3Cards :: Situations
 oneDiamond3Cards = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            suitLength T.Spades   4
-            suitLength T.Hearts   4
-            suitLength T.Diamonds 3
-            suitLength T.Clubs    2
-            withholdBid SO.b1d
-        explanation fmt =
-            "With no 5-card major and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
-          \ diamonds is your only minor, even if you only have 3 of them. The \
-          \ only time you'd open 1D with a 3-card suit in standard openings is \
-          \ when your shape is exactly 4=4=3=2."
-      in
-        situation "1D4432" dealer vul action (T.Bid 1 T.Diamonds) explanation
+    action = do
+        B.setOpener T.South
+        suitLength T.Spades   4
+        suitLength T.Hearts   4
+        suitLength T.Diamonds 3
+        suitLength T.Clubs    2
+        withholdBid SO.b1d
+    explanation fmt =
+        "With no 5-card major and a hand unsuitable for opening \
+      \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
+      \ diamonds is your only minor, even if you only have 3 of them. The \
+      \ only time you'd open 1D with a 3-card suit in standard openings is \
+      \ when your shape is exactly 4=4=3=2."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1D4432" action (T.Bid 1 T.Diamonds) explanation
 
 
 oneClub :: Situations
 oneClub = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            maxSuitLength T.Diamonds 3
-            minSuitLength T.Clubs 4
-            withholdBid SO.b1c
-        explanation fmt =
-            "With no 5-card major and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
-          \ clubs is your only minor."
-      in
-        situation "1C1Suit" dealer vul action (T.Bid 1 T.Clubs) explanation
+    action = do
+        B.setOpener T.South
+        maxSuitLength T.Diamonds 3
+        minSuitLength T.Clubs 4
+        withholdBid SO.b1c
+    explanation fmt =
+        "With no 5-card major and a hand unsuitable for opening \
+      \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
+      \ clubs is your only minor."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "1C1Suit" action (T.Bid 1 T.Clubs) explanation
 
 
 oneClubEqualMinors :: Situations
 oneClubEqualMinors = let
-    sit len dealer vul = let
+    sit len = let
         action = do
             B.setOpener T.South
             suitLength T.Diamonds len
@@ -187,68 +161,59 @@ oneClubEqualMinors = let
           \ your minors are of equal, short length. As the saying goes, \
           \ ``up the line with 3s and 4s, from the top with 5s or mores.''"
       in
-        situation "1C1Suit" dealer vul action (T.Bid 1 T.Clubs) explanation
+        situation "1C1Suit" action (T.Bid 1 T.Clubs) explanation
   in
-    wrap $ base sit <~ [3, 4] <~ T.allDirections <~ T.allVulnerabilities
+    wrapVulDlr $ base sit <~ [3, 4]
 
 
 bothMinorsNoReverse :: Situations
 bothMinorsNoReverse = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            minSuitLength T.Diamonds 5
-            minSuitLength T.Clubs 5
-            withholdBid SO.b1d
-        explanation fmt =
-            "With both minors but not enough strength to reverse, open, " ++
-            output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
-            output fmt (T.Bid 2 T.Clubs) ++ " next turn."
-      in
-        situation "MinNoRev" dealer vul action (T.Bid 1 T.Diamonds) explanation
+    action = do
+        B.setOpener T.South
+        minSuitLength T.Diamonds 5
+        minSuitLength T.Clubs 5
+        withholdBid SO.b1d
+    explanation fmt =
+        "With both minors but not enough strength to reverse, open, " ++
+        output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
+        output fmt (T.Bid 2 T.Clubs) ++ " next turn."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "MinNoRev" action (T.Bid 1 T.Diamonds) explanation
 
 
 bothMinorsNoReverseShortD :: Situations
 bothMinorsNoReverseShortD = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            suitLength T.Diamonds 4
-            suitLength T.Clubs 5
-            withholdBid SO.b1d
-        explanation fmt =
-            "With both minors but not enough strength to reverse, open " ++
-            output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
-            output fmt (T.Bid 2 T.Clubs) ++ " next turn. This is even the case\
-          \ when your clubs are longer than your diamonds! Bidding clubs first\
-          \ and diamonds second is a reverse (responder can't go back to your\
-          \ first suit without going to the 3 level), and cannot be bid without\
-          \ enough strength to make a 3-level contract viable when partner has\
-          \ a minimum."
-      in
-        situation "MinNoRv4D" dealer vul action (T.Bid 1 T.Diamonds) explanation
+    action = do
+        B.setOpener T.South
+        suitLength T.Diamonds 4
+        suitLength T.Clubs 5
+        withholdBid SO.b1d
+    explanation fmt =
+        "With both minors but not enough strength to reverse, open " ++
+        output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
+        output fmt (T.Bid 2 T.Clubs) ++ " next turn. This is even the case\
+      \ when your clubs are longer than your diamonds! Bidding clubs first\
+      \ and diamonds second is a reverse (responder can't go back to your\
+      \ first suit without going to the 3 level), and cannot be bid without\
+      \ enough strength to make a 3-level contract viable when partner has\
+      \ a minimum."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "MinNoRv4D" action (T.Bid 1 T.Diamonds) explanation
 
 
 bothMinorsReverse :: Situations
 bothMinorsReverse = let
-    sit dealer vul = let
-        action = do
-            B.setOpener T.South
-            minSuitLength T.Diamonds 5
-            minSuitLength T.Clubs 5
-            withholdBid SO.b1c
-        explanation fmt =
-            "With both minors and enough strength to reverse, open, " ++
-            output fmt (T.Bid 1 T.Clubs) ++ ", planning to rebid " ++
-            output fmt (T.Bid 2 T.Diamonds) ++ " next turn."
-      in
-        situation "MinRev55" dealer vul action (T.Bid 1 T.Clubs) explanation
+    action = do
+        B.setOpener T.South
+        minSuitLength T.Diamonds 5
+        minSuitLength T.Clubs 5
+        withholdBid SO.b1c
+    explanation fmt =
+        "With both minors and enough strength to reverse, open, " ++
+        output fmt (T.Bid 1 T.Clubs) ++ ", planning to rebid " ++
+        output fmt (T.Bid 2 T.Diamonds) ++ " next turn."
   in
-    wrap $ base sit <~ T.allDirections <~ T.allVulnerabilities
+    stdWrap $ situation "MinRev55" action (T.Bid 1 T.Clubs) explanation
 
 
 


### PR DESCRIPTION
Many situations work for any vulnerability and any dealer. So, put those parameters last, and make helper functions that parameterize over them. 

I haven't yet removed the boilerplate of combining `base` and `situation` into a single function, but I suspect that's doable in the near future, too.