### PR TITLE
Standard Modern Precision: opening bids and immediate responses to 1C openers

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,11 +2,12 @@ import System.Random(mkStdGen)
 
 --import qualified Topics.JacobyTransfers as JacobyTransfers
 --import qualified Topics.MinorTransfersScott as MinorTransfers
-import qualified Topics.PrecisionOpeners as PrecisionOpeners
+--import qualified Topics.PrecisionOpeners as PrecisionOpeners
 --import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
 --import qualified Topics.StandardOpeners as StandardOpeners
+import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
-main = outputLatex 100 [PrecisionOpeners.topic] "test" (mkStdGen 0) >> return ()
+main = outputLatex 100 [SmpOpenings.topic] "test" (mkStdGen 0) >> return ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,8 +6,9 @@ import System.Random(mkStdGen)
 --import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
 --import qualified Topics.StandardOpeners as StandardOpeners
 import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
+import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
-main = outputLatex 100 [SmpOpenings.topic] "test" (mkStdGen 0) >> return ()
+main = outputLatex 100 [SmpOpenings.topic, Smp1CResponses.topic] "test" (mkStdGen 0) >> return ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,11 +2,11 @@ import System.Random(mkStdGen)
 
 --import qualified Topics.JacobyTransfers as JacobyTransfers
 --import qualified Topics.MinorTransfersScott as MinorTransfers
---import qualified Topics.PrecisionOpeners as PrecisionOpeners
+import qualified Topics.PrecisionOpeners as PrecisionOpeners
 --import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
-import qualified Topics.StandardOpeners as StandardOpeners
+--import qualified Topics.StandardOpeners as StandardOpeners
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
-main = outputLatex 100 [StandardOpeners.topic] "test" (mkStdGen 0) >> return ()
+main = outputLatex 100 [PrecisionOpeners.topic] "test" (mkStdGen 0) >> return ()

--- a/src/Topics/PrecisionOpeners.hs
+++ b/src/Topics/PrecisionOpeners.hs
@@ -88,7 +88,7 @@ oneDiamond = let
         "With opening strength but not enough for a strong " ++
         output fmt (T.Bid 1 T.Clubs) ++ " and no 5-card major or 6-card\
       \ club suit, open a diamond. Partner will announce that it ``could\
-      \ be short.''"
+      \ be as short as 2.''"
   in
     stdWrap $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
 

--- a/src/Topics/StandardModernPrecision/Bids.hs
+++ b/src/Topics/StandardModernPrecision/Bids.hs
@@ -1,0 +1,100 @@
+module Topics.StandardModernPrecision.Bids(
+    firstSeatOpener
+  , b1C
+  , b1D
+  , b1M
+  , b1N
+  , b2C
+  , b2D
+  , b2N
+  , smpWrapN
+  , smpWrapS
+) where
+
+import Topic(wrap, Situations)
+import Auction(forbid, pointRange, minSuitLength, Action, balancedHand,
+               constrain, makeCall)
+import Situation(Situation, base, (<~))
+import qualified Terminology as T
+
+
+-- Because we're not using the Rule of 20 and its ilk, we're going to skip the
+-- auctions that start with other folks passing for now, and maybe come back to
+-- those later.
+-- TODO: figure out how to practice the auctions that start P-1C-1S (with 1S
+-- being game forcing and natural 5-card spade suit, rather than slam forcing)
+firstSeatOpener :: Action
+firstSeatOpener = do
+    pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
+
+
+b1N :: Action
+b1N = do
+    pointRange 14 16
+    balancedHand
+    makeCall $ T.Bid 1 T.Notrump
+
+
+b2N :: Action
+b2N = do
+    pointRange 19 21  -- A modification from Part 1: it's really 19 to a bad 21
+    balancedHand
+    makeCall $ T.Bid 2 T.Notrump
+
+
+b1C :: Action
+b1C = do
+    pointRange 16 40
+    forbid b1N
+    forbid b2N
+    makeCall $ T.Bid 1 T.Clubs
+
+
+b1M :: T.Suit -> Action
+b1M suit = do
+    forbid b1C
+    forbid b1N
+    minSuitLength suit 5
+    makeCall $ T.Bid 1 suit
+
+
+b2C :: Action
+b2C = do
+    forbid b1C
+    forbid (b1M T.Hearts)
+    forbid (b1M T.Spades)
+    minSuitLength T.Clubs 6
+    makeCall $ T.Bid 2 T.Clubs
+
+
+b2D :: Action
+b2D = do
+    forbid b1C
+    constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
+    makeCall $ T.Bid 2 T.Diamonds
+
+
+b1D :: Action
+b1D = do
+    sequence_ . map forbid $ [ b1C
+                             , b1N
+                             , b1M T.Hearts
+                             , b1M T.Spades
+                             , b2C
+                             , b2D
+                             ]
+    -- The next line is commented out because if it can be violated, we're gonna
+    -- have a bad day. Make sure that it's never violated in the results even if
+    -- it's not explicitly required.
+    --minSuitLength T.Diamonds 2
+    makeCall $ T.Bid 1 T.Diamonds
+
+
+-- syntactic sugar: Always make opener be in first seat, until we figure out how
+-- to open in other seats.
+-- TODO: change this to let other folks be dealer, too
+smpWrapS :: (T.Vulnerability -> T.Direction -> Situation) -> Situations
+smpWrapS sit = wrap $ base sit <~ T.allVulnerabilities <~ [T.South]
+
+smpWrapN :: (T.Vulnerability -> T.Direction -> Situation) -> Situations
+smpWrapN sit = wrap $ base sit <~ T.allVulnerabilities <~ [T.North]

--- a/src/Topics/StandardModernPrecision/Bids.hs
+++ b/src/Topics/StandardModernPrecision/Bids.hs
@@ -35,8 +35,6 @@ import qualified Terminology as T
 -- Because we're not using the Rule of 20 and its ilk, we're going to skip the
 -- auctions that start with other folks passing for now, and maybe come back to
 -- those later.
--- TODO: figure out how to practice the auctions that start P-1C-1S (with 1S
--- being game forcing and natural 5-card spade suit, rather than slam forcing)
 firstSeatOpener :: Action
 firstSeatOpener = do
     pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify

--- a/src/Topics/StandardModernPrecision/Bids.hs
+++ b/src/Topics/StandardModernPrecision/Bids.hs
@@ -7,13 +7,27 @@ module Topics.StandardModernPrecision.Bids(
   , b2C
   , b2D
   , b2N
+  , b1C1D
+  , b1C1H
+  , b1C1S
+  , b1C1N
+  , b1C2C
+  , b1C2D
+  , b1C2H
+  , b1C2S
+  , bP1C1H
+  , bP1C1S
+  , bP1C1N
+  , bP1C2C
+  , bP1C2D
+  , bP1C2S  -- Note that the auction P-1C-2H cannot occur!
   , smpWrapN
   , smpWrapS
 ) where
 
 import Topic(wrap, Situations)
-import Auction(forbid, pointRange, minSuitLength, Action, balancedHand,
-               constrain, makeCall)
+import Auction(forbid, pointRange, minSuitLength, maxSuitLength, Action,
+               balancedHand, constrain, makeCall)
 import Situation(Situation, base, (<~))
 import qualified Terminology as T
 
@@ -27,7 +41,9 @@ firstSeatOpener :: Action
 firstSeatOpener = do
     pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
 
-
+------------------
+-- Opening bids --
+------------------
 b1N :: Action
 b1N = do
     pointRange 14 16
@@ -90,8 +106,102 @@ b1D = do
     makeCall $ T.Bid 1 T.Diamonds
 
 
--- syntactic sugar: Always make opener be in first seat, until we figure out how
--- to open in other seats.
+---------------------
+-- Responses to 1C --
+---------------------
+b1C1D :: Action
+b1C1D = pointRange 0 7
+
+_gameForcing :: Action
+_gameForcing = pointRange 8 11
+
+_slamInterest :: Action
+_slamInterest = pointRange 12 40
+
+
+b1C1H :: Action
+b1C1H = _gameForcing
+
+
+b1C1S :: Action
+b1C1S = do
+    _slamInterest
+    minSuitLength T.Spades 5
+
+
+b1C2C :: Action
+b1C2C = do
+    _slamInterest
+    minSuitLength T.Clubs 5
+
+
+b1C2D :: Action
+b1C2D = do
+    _slamInterest
+    minSuitLength T.Diamonds 5
+
+
+b1C2H :: Action
+b1C2H = do
+    _slamInterest
+    minSuitLength T.Hearts 5
+
+
+b1C1N :: Action
+b1C1N = do
+    _slamInterest
+    balancedHand
+    sequence_ . map (\s -> maxSuitLength s 4) $ T.allSuits
+
+
+b1C2S :: Action
+b1C2S = do
+    _slamInterest
+    constrain "triple41" ["shape(", ", 4441 + 4414 + 4144 + 1444)"]
+
+
+bP1C1H :: Action
+bP1C1H = do
+    _gameForcing
+    minSuitLength T.Hearts 5
+
+
+bP1C1S :: Action
+bP1C1S = do
+    _gameForcing
+    minSuitLength T.Spades 5
+
+
+bP1C2C :: Action
+bP1C2C = do
+    _gameForcing
+    minSuitLength T.Clubs 5
+
+
+bP1C2D :: Action
+bP1C2D = do
+    _gameForcing
+    minSuitLength T.Diamonds 5
+
+
+bP1C1N :: Action
+bP1C1N = do
+    _gameForcing
+    balancedHand
+    sequence_ . map (\s -> maxSuitLength s 4) $ T.allSuits
+
+
+bP1C2S :: Action
+bP1C2S = do
+    _gameForcing
+    constrain "triple41" ["shape(", ", 4441 + 4414 + 4144 + 1444)"]
+
+
+-------------------------------
+-- Situation syntactic sugar --
+-------------------------------
+-- Always make opener be in first seat, until we figure out how to open in other
+-- seats.
 -- TODO: change this to let other folks be dealer, too
 smpWrapS :: (T.Vulnerability -> T.Direction -> Situation) -> Situations
 smpWrapS sit = wrap $ base sit <~ T.allVulnerabilities <~ [T.South]

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -1,0 +1,188 @@
+module Topics.StandardModernPrecision.OpeningBids(
+    topic
+  , firstSeatOpener  -- Find a different place to put these.
+  , oneClubOpener) where
+
+import Output(output)
+import Topic(Topic(..), wrap, Situations)
+import Auction(forbid, pointRange, minSuitLength, Action, balancedHand,
+               constrain)
+import Situation(Situation, situation, base, (<~))
+import qualified Terminology as T
+
+
+-- Because we're not using the Rule of 20 and its ilk, we're going to skip the
+-- auctions that start with other folks passing for now, and maybe come back to
+-- those later.
+-- TODO: figure out how to practice the auctions that start P-1C-1S (with 1S
+-- being game forcing and natural 5-card spade suit, rather than slam forcing)
+firstSeatOpener :: Action
+firstSeatOpener = do
+    pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
+
+
+oneNotrumpOpener :: Action
+oneNotrumpOpener = do
+    pointRange 14 16
+    balancedHand
+
+
+twoNotrumpOpener :: Action
+twoNotrumpOpener = do
+    pointRange 19 21  -- A modification from Part 1: it's really 19 to a bad 21
+    balancedHand
+
+
+oneClubOpener :: Action
+oneClubOpener = do
+    pointRange 16 40
+    forbid oneNotrumpOpener
+    forbid twoNotrumpOpener
+
+
+oneMajorOpener :: T.Suit -> Action
+oneMajorOpener suit = do
+    forbid oneClubOpener
+    forbid oneNotrumpOpener
+    minSuitLength suit 5
+
+
+twoClubOpener :: Action
+twoClubOpener = do
+    forbid oneClubOpener
+    forbid (oneMajorOpener T.Hearts)
+    forbid (oneMajorOpener T.Spades)
+    minSuitLength T.Clubs 6
+
+
+twoDiamondOpener :: Action
+twoDiamondOpener = do
+    forbid oneClubOpener
+    constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
+
+
+oneDiamondOpener :: Action
+oneDiamondOpener = do
+    sequence_ . map forbid $ [ oneClubOpener
+                             , oneNotrumpOpener
+                             , oneMajorOpener T.Hearts
+                             , oneMajorOpener T.Spades
+                             , twoClubOpener
+                             , twoDiamondOpener
+                             ]
+    -- The next line is commented out because if it can be violated, we're gonna
+    -- have a bad day. Make sure that it's never violated in the results even if
+    -- it's not explicitly required.
+    --minSuitLength T.Diamonds 2
+
+
+-- syntactic sugar: always make South the dealer
+-- TODO: change this to let other folks be dealer, too
+smpWrap :: (T.Vulnerability -> T.Direction -> Situation) -> Situations
+smpWrap sit = wrap $ base sit <~ T.allVulnerabilities <~ [T.South]
+
+
+oneClub :: Situations
+oneClub = let
+    action = do
+        firstSeatOpener
+        oneClubOpener
+    explanation fmt =
+        "With 16 or more points (17 or more when balanced), open a strong " ++
+        output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of SMP."
+  in
+    smpWrap $ situation "1C" action (T.Bid 1 T.Clubs) explanation
+
+
+oneDiamond :: Situations
+oneDiamond = let
+    action = do
+        firstSeatOpener
+        oneDiamondOpener
+    explanation fmt =
+        "With opening strength but the wrong strength/shape for any other\
+      \ opening bid, start with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ".\
+      \ Partner will announce that it ``could be as short as 2.''"
+  in
+    smpWrap $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
+
+
+oneMajor :: Situations
+oneMajor = let
+    sit suit = let
+        action = do
+            firstSeatOpener
+            oneMajorOpener suit
+            -- TODO: What if you're 5-5?
+        explanation fmt =
+            "With opening strength but not enough for a strong " ++
+            output fmt (T.Bid 1 T.Clubs) ++ " or " ++
+            output fmt (T.Bid 1 T.Notrump) ++ ", open a 5-card major suit."
+      in
+        situation "1M" action (T.Bid 1 suit) explanation
+  in
+    -- TODO: figure out some syntactic sugar for this, too
+    wrap $ base sit <~ T.majorSuits <~ T.allVulnerabilities <~ [T.South]
+
+
+oneNotrump :: Situations
+oneNotrump = let
+    action = do
+        firstSeatOpener
+        oneNotrumpOpener
+    explanation fmt =
+        "With a balanced hand and 14-16 HCP, open " ++
+        output fmt (T.Bid 1 T.Notrump) ++ "."
+  in
+    smpWrap $ situation "1N" action (T.Bid 1 T.Notrump) explanation
+
+
+twoClubs :: Situations
+twoClubs = let
+    action = do
+        firstSeatOpener
+        twoClubOpener
+    explanation fmt =
+        "With a 6-card club suit, no 5-card major, an opening hand but not a\
+       \ hand strong enough to open " ++ output fmt (T.Bid 1 T.Clubs) ++ ",\
+       \ open " ++ output fmt (T.Bid 2 T.Clubs) ++ "."
+  in
+    smpWrap $ situation "2C" action (T.Bid 2 T.Clubs) explanation
+
+
+twoDiamonds :: Situations
+twoDiamonds = let
+    action = do
+        firstSeatOpener
+        twoDiamondOpener
+    explanation fmt =
+        "The " ++ output fmt (T.Bid 2 T.Diamonds) ++ " hand is that 3-suited\
+       \ hand without diamonds, which can be thought of as a 14-card hand with\
+       \ 4415 shape but missing any single card."
+  in
+    smpWrap $ situation "2D" action (T.Bid 2 T.Diamonds) explanation
+
+
+twoNotrump :: Situations
+twoNotrump = let
+    action = do
+        firstSeatOpener
+        twoNotrumpOpener
+    explanation fmt =
+        "With a balanced hand and 19 to a bad 21 HCP, open " ++
+        output fmt (T.Bid 2 T.Notrump) ++ "."
+  in
+    smpWrap $ situation "2N" action (T.Bid 2 T.Notrump) explanation
+
+
+topic :: Topic
+topic = Topic "SMP opening bids" "SmpOpen" situations
+  where
+    situations = wrap [ oneClub
+                      , oneDiamond
+                      , oneMajor
+                      , oneNotrump
+                      , twoClubs
+                      , twoDiamonds
+                      , twoNotrump
+                      ]

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -1,118 +1,44 @@
-module Topics.StandardModernPrecision.OpeningBids(
-    topic
-  , firstSeatOpener  -- Find a different place to put these.
-  , oneClubOpener) where
+module Topics.StandardModernPrecision.OpeningBids(topic) where
 
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
-import Auction(forbid, pointRange, minSuitLength, Action, balancedHand,
-               constrain)
-import Situation(Situation, situation, base, (<~))
+import Auction(withholdBid)
+import Situation(situation, base, (<~))
 import qualified Terminology as T
-
-
--- Because we're not using the Rule of 20 and its ilk, we're going to skip the
--- auctions that start with other folks passing for now, and maybe come back to
--- those later.
--- TODO: figure out how to practice the auctions that start P-1C-1S (with 1S
--- being game forcing and natural 5-card spade suit, rather than slam forcing)
-firstSeatOpener :: Action
-firstSeatOpener = do
-    pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
-
-
-oneNotrumpOpener :: Action
-oneNotrumpOpener = do
-    pointRange 14 16
-    balancedHand
-
-
-twoNotrumpOpener :: Action
-twoNotrumpOpener = do
-    pointRange 19 21  -- A modification from Part 1: it's really 19 to a bad 21
-    balancedHand
-
-
-oneClubOpener :: Action
-oneClubOpener = do
-    pointRange 16 40
-    forbid oneNotrumpOpener
-    forbid twoNotrumpOpener
-
-
-oneMajorOpener :: T.Suit -> Action
-oneMajorOpener suit = do
-    forbid oneClubOpener
-    forbid oneNotrumpOpener
-    minSuitLength suit 5
-
-
-twoClubOpener :: Action
-twoClubOpener = do
-    forbid oneClubOpener
-    forbid (oneMajorOpener T.Hearts)
-    forbid (oneMajorOpener T.Spades)
-    minSuitLength T.Clubs 6
-
-
-twoDiamondOpener :: Action
-twoDiamondOpener = do
-    forbid oneClubOpener
-    constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
-
-
-oneDiamondOpener :: Action
-oneDiamondOpener = do
-    sequence_ . map forbid $ [ oneClubOpener
-                             , oneNotrumpOpener
-                             , oneMajorOpener T.Hearts
-                             , oneMajorOpener T.Spades
-                             , twoClubOpener
-                             , twoDiamondOpener
-                             ]
-    -- The next line is commented out because if it can be violated, we're gonna
-    -- have a bad day. Make sure that it's never violated in the results even if
-    -- it's not explicitly required.
-    --minSuitLength T.Diamonds 2
-
-
--- syntactic sugar: always make South the dealer
--- TODO: change this to let other folks be dealer, too
-smpWrap :: (T.Vulnerability -> T.Direction -> Situation) -> Situations
-smpWrap sit = wrap $ base sit <~ T.allVulnerabilities <~ [T.South]
+import qualified Topics.StandardModernPrecision.Bids as B
 
 
 oneClub :: Situations
 oneClub = let
     action = do
-        firstSeatOpener
-        oneClubOpener
+        B.firstSeatOpener
+        withholdBid B.b1C
     explanation fmt =
         "With 16 or more points (17 or more when balanced), open a strong " ++
         output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of SMP."
   in
-    smpWrap $ situation "1C" action (T.Bid 1 T.Clubs) explanation
+    B.smpWrapS $ situation "1C" action (T.Bid 1 T.Clubs) explanation
 
 
 oneDiamond :: Situations
 oneDiamond = let
     action = do
-        firstSeatOpener
-        oneDiamondOpener
+        B.firstSeatOpener
+        withholdBid B.b1D
     explanation fmt =
         "With opening strength but the wrong strength/shape for any other\
       \ opening bid, start with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ".\
       \ Partner will announce that it ``could be as short as 2.''"
   in
-    smpWrap $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
+    B.smpWrapS $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
 
 
 oneMajor :: Situations
 oneMajor = let
     sit suit = let
         action = do
-            firstSeatOpener
-            oneMajorOpener suit
+            B.firstSeatOpener
+            withholdBid $ B.b1M suit
             -- TODO: What if you're 5-5?
         explanation fmt =
             "With opening strength but not enough for a strong " ++
@@ -128,51 +54,51 @@ oneMajor = let
 oneNotrump :: Situations
 oneNotrump = let
     action = do
-        firstSeatOpener
-        oneNotrumpOpener
+        B.firstSeatOpener
+        withholdBid B.b1N
     explanation fmt =
         "With a balanced hand and 14-16 HCP, open " ++
         output fmt (T.Bid 1 T.Notrump) ++ "."
   in
-    smpWrap $ situation "1N" action (T.Bid 1 T.Notrump) explanation
+    B.smpWrapS $ situation "1N" action (T.Bid 1 T.Notrump) explanation
 
 
 twoClubs :: Situations
 twoClubs = let
     action = do
-        firstSeatOpener
-        twoClubOpener
+        B.firstSeatOpener
+        withholdBid B.b2C
     explanation fmt =
         "With a 6-card club suit, no 5-card major, an opening hand but not a\
        \ hand strong enough to open " ++ output fmt (T.Bid 1 T.Clubs) ++ ",\
        \ open " ++ output fmt (T.Bid 2 T.Clubs) ++ "."
   in
-    smpWrap $ situation "2C" action (T.Bid 2 T.Clubs) explanation
+    B.smpWrapS $ situation "2C" action (T.Bid 2 T.Clubs) explanation
 
 
 twoDiamonds :: Situations
 twoDiamonds = let
     action = do
-        firstSeatOpener
-        twoDiamondOpener
+        B.firstSeatOpener
+        withholdBid B.b2D
     explanation fmt =
         "The " ++ output fmt (T.Bid 2 T.Diamonds) ++ " hand is that 3-suited\
        \ hand without diamonds, which can be thought of as a 14-card hand with\
        \ 4415 shape but missing any single card."
   in
-    smpWrap $ situation "2D" action (T.Bid 2 T.Diamonds) explanation
+    B.smpWrapS $ situation "2D" action (T.Bid 2 T.Diamonds) explanation
 
 
 twoNotrump :: Situations
 twoNotrump = let
     action = do
-        firstSeatOpener
-        twoNotrumpOpener
+        B.firstSeatOpener
+        withholdBid B.b2N
     explanation fmt =
         "With a balanced hand and 19 to a bad 21 HCP, open " ++
         output fmt (T.Bid 2 T.Notrump) ++ "."
   in
-    smpWrap $ situation "2N" action (T.Bid 2 T.Notrump) explanation
+    B.smpWrapS $ situation "2N" action (T.Bid 2 T.Notrump) explanation
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
+++ b/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
@@ -1,0 +1,119 @@
+module Topics.StandardModernPrecision.ResponsesToStrongClub(topic) where
+
+import Output(output)
+import Topic(Topic(..), wrap, Situations)
+import Auction(withholdBid, makePass)
+import Situation(situation)--, base, (<~))
+import CommonBids(cannotPreempt)
+import qualified Terminology as T
+import qualified Topics.StandardModernPrecision.Bids as B
+
+
+oneDiamond :: Situations
+oneDiamond = let
+    action = do
+        B.firstSeatOpener
+        B.b1C
+        cannotPreempt
+        makePass
+        withholdBid B.b1C1D
+    explanation fmt =
+        "When game might not be possible opposite a random 17 HCP, start\
+      \ with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ". This is the start of\
+      \ MaFiA."
+  in
+    B.smpWrapN $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
+
+
+oneHeart :: Situations
+oneHeart = let
+    action = do
+        B.firstSeatOpener
+        B.b1C
+        cannotPreempt
+        makePass
+        withholdBid B.b1C1H
+    explanation fmt =
+        "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP,\
+      \ bid " ++ output fmt (T.Bid 1 T.Hearts) ++ " to show this kind of hand.\
+      \ Subsequent bids are natural 5-card suits, not MaFiA."
+  in
+    B.smpWrapN $ situation "1H" action (T.Bid 1 T.Hearts) explanation
+
+
+oneSpade :: Situations
+oneSpade = let
+    action = do
+        B.firstSeatOpener
+        B.b1C
+        cannotPreempt
+        makePass
+        withholdBid B.b1C1S
+    explanation fmt =
+        "You've got at least mild slam interest with 12+ HCP, and a 5+ card\
+      \ major. Bid a natural " ++ output fmt (T.Bid 1 T.Spades) ++ ", and we'll\
+      \ go from there. Once we find a trump fit, we'll start control bidding.\
+      \ Subsequent bids are natural 5-card suits, not MaFiA."
+  in
+    B.smpWrapN $ situation "1S" action (T.Bid 1 T.Spades) explanation
+
+
+oneNotrump :: Situations
+oneNotrump = let
+    action = do
+        B.firstSeatOpener
+        B.b1C
+        cannotPreempt
+        makePass
+        withholdBid B.b1C1N
+    explanation fmt =
+        "You've got at least mild slam interest with 12+ HCP, and a balanced\
+      \ hand with no 5-card suit. Bid a natural " ++
+        output fmt (T.Bid 1 T.Notrump) ++ ", and we'll\
+      \ go from there. Systems are on, even though this might wrong-side the\
+      \ contract: better to be familiar and easy to remember than right-side\
+      \ it, at least until we're more practiced with SMP."
+  in
+    B.smpWrapN $ situation "1N" action (T.Bid 1 T.Notrump) explanation
+
+
+twoSpades :: Situations
+twoSpades = let
+    action = do
+        B.firstSeatOpener
+        B.b1C
+        cannotPreempt
+        makePass
+        withholdBid B.b1C2S
+    explanation fmt =
+        "You've got at least mild slam interest with 12+ HCP, but an awkward\
+      \ triple four one shape. Show this by bidding " ++
+        output fmt (T.Bid 2 T.Spades) ++ ". Partner will relay to " ++
+        output fmt (T.Bid 2 T.Notrump) ++ ", then bid your singleton. Partner\
+      \ will then either set trump for us to start control bidding, or use " ++
+        output fmt (T.Bid 4 T.Clubs) ++ "/" ++
+        output fmt (T.Bid 4 T.Diamonds) ++ "/RKC."
+  in
+    B.smpWrapN $ situation "2S" action (T.Bid 2 T.Spades) explanation
+
+
+topic :: Topic
+topic = Topic "SMP immediate responses to 1C" "SMP1C" situations
+  where
+    situations = wrap [ oneDiamond
+                      , oneHeart
+                      , oneSpade
+                      , oneNotrump
+                      , twoSpades
+{-
+                      , twoClubs
+                      , twoDiamonds
+                      , twoHearts
+                      , passOneHeart
+                      , passOneSpade
+                      , passOneNotrump
+                      , passTwoClubs
+                      , passTwoDiamonds
+                      , passTwoSpades
+-}
+                      ]


### PR DESCRIPTION
...though not yet including two-suited slam-interest responses. 

There are some brittle parts around how to ensure that the opponents aren't bidding when we don't want them to, but that can be cleaned up another time.

I need to finish the branch with support for explanations of alertable bids; that's going to be important!