### PR TITLE
Cleanup and refactor

### DIFF
--- a/src/Auction.hs
+++ b/src/Auction.hs
@@ -77,7 +77,6 @@ makeCall :: T.Call -> Action
 makeCall call = modify $ first (>- T.CompleteCall call Nothing)
 
 makeAlertableCall :: T.Call -> String -> Action
-makeAlertableCall call alert = do
 makeAlertableCall call alert =
     modify $ first (>- T.CompleteCall call (Just alert))
 

--- a/src/Topics/StandardModernPrecision/BasicBids.hs
+++ b/src/Topics/StandardModernPrecision/BasicBids.hs
@@ -1,0 +1,126 @@
+module Topics.StandardModernPrecision.BasicBids(
+    firstSeatOpener
+  , oppsPass
+  -- Opening bids
+  , b1C
+  , b1D
+  , b1M
+  , b1N
+  , b2C
+  , b2D
+  , b2N
+  , b3N
+  -- syntactic sugar
+  , smpWrapN
+  , smpWrapS
+) where
+
+import System.Random(StdGen)
+
+import Topic(wrap, Situations)
+import Auction(forbid, pointRange, minSuitLength,
+               Action, balancedHand, constrain, makeCall, makeAlertableCall,
+               makePass)
+import Situation(Situation, (<~))
+import CommonBids(cannotPreempt)
+import qualified Terminology as T
+
+
+-- Because we're not using the Rule of 20 and its ilk, we're going to skip the
+-- auctions that start with other folks passing for now, and maybe come back to
+-- those later.
+firstSeatOpener :: Action
+firstSeatOpener = do
+    pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
+
+
+oppsPass :: Action
+oppsPass = do
+    cannotPreempt
+    makePass
+
+
+------------------
+-- Opening bids --
+------------------
+b1N :: Action
+b1N = do
+    pointRange 14 16
+    balancedHand
+    makeAlertableCall (T.Bid 1 T.Notrump) "14-16"
+
+
+b2N :: Action
+b2N = do
+    pointRange 19 20  -- A modification from Part 1
+    balancedHand
+    makeCall $ T.Bid 2 T.Notrump
+
+
+b3N :: Action
+b3N = do
+    pointRange 24 40  -- Technically only 24-27, but close enough
+    balancedHand
+    makeCall $ T.Bid 3 T.Notrump
+
+
+b1C :: Action
+b1C = do
+    pointRange 16 40
+    sequence_ . map forbid $ [b1N, b2N, b3N]
+    makeAlertableCall (T.Bid 1 T.Clubs) "16+ HCP"
+
+
+b1M :: T.Suit -> Action
+b1M suit = do
+    forbid b1C
+    forbid b1N
+    minSuitLength suit 5
+    makeCall $ T.Bid 1 suit
+
+
+b2C :: Action
+b2C = do
+    forbid b1C
+    forbid (b1M T.Hearts)
+    forbid (b1M T.Spades)
+    minSuitLength T.Clubs 6
+    makeAlertableCall (T.Bid 2 T.Clubs) "6+ clubs"
+
+
+b2D :: Action
+b2D = do
+    forbid b1C
+    constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
+    makeAlertableCall (T.Bid 2 T.Diamonds) "4414, 4315, 3415, or 4405 shape"
+
+
+b1D :: Action
+b1D = do
+    sequence_ . map forbid $ [ b1C
+                             , b1N
+                             , b1M T.Hearts
+                             , b1M T.Spades
+                             , b2C
+                             , b2D
+                             ]
+    -- The next line is commented out because if it can be violated, we're gonna
+    -- have a bad day. Make sure that it's never violated in the results even if
+    -- it's not explicitly required.
+    --minSuitLength T.Diamonds 2
+    makeAlertableCall (T.Bid 1 T.Diamonds) "Could be as short as 2 diamonds"
+
+
+-------------------------------
+-- Situation syntactic sugar --
+-------------------------------
+-- Always make opener be in first seat, until we figure out how to open in other
+-- seats.
+-- TODO: change this to let other folks be dealer, too
+smpWrapS :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
+            Situations
+smpWrapS sit = wrap $ sit <~ T.allVulnerabilities <~ [T.South]
+
+smpWrapN :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
+            Situations
+smpWrapN sit = wrap $ sit <~ T.allVulnerabilities <~ [T.North]

--- a/src/Topics/StandardModernPrecision/BasicBids.hs
+++ b/src/Topics/StandardModernPrecision/BasicBids.hs
@@ -73,6 +73,7 @@ b1C = do
 
 b1M :: T.Suit -> Action
 b1M suit = do
+    firstSeatOpener
     forbid b1C
     forbid b1N
     minSuitLength suit 5
@@ -81,6 +82,7 @@ b1M suit = do
 
 b2C :: Action
 b2C = do
+    firstSeatOpener
     forbid b1C
     forbid (b1M T.Hearts)
     forbid (b1M T.Spades)
@@ -90,6 +92,7 @@ b2C = do
 
 b2D :: Action
 b2D = do
+    firstSeatOpener
     forbid b1C
     constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
     makeAlertableCall (T.Bid 2 T.Diamonds) "4414, 4315, 3415, or 4405 shape"
@@ -97,6 +100,7 @@ b2D = do
 
 b1D :: Action
 b1D = do
+    firstSeatOpener
     sequence_ . map forbid $ [ b1C
                              , b1N
                              , b1M T.Hearts

--- a/src/Topics/StandardModernPrecision/Bids.hs
+++ b/src/Topics/StandardModernPrecision/Bids.hs
@@ -96,14 +96,14 @@ b1N = do
 
 b2N :: Action
 b2N = do
-    pointRange 19 21  -- A modification from Part 1: it's really 19 to a bad 21
+    pointRange 19 20  -- A modification from Part 1
     balancedHand
     makeCall $ T.Bid 2 T.Notrump
 
 
 b3N :: Action
 b3N = do
-    pointRange 25 40  -- Technically only 25-27, but close enough
+    pointRange 24 40  -- Technically only 24-27, but close enough
     balancedHand
     makeCall $ T.Bid 3 T.Notrump
 
@@ -277,7 +277,7 @@ startOfMafia = do
 -- Do the game-forcing bids first
 b1C1D2N :: Action
 b1C1D2N = do
-    pointRange 22 24
+    pointRange 21 23
     balancedHand
     makeCall $ T.Bid 2 T.Notrump
 

--- a/src/Topics/StandardModernPrecision/Bids1C.hs
+++ b/src/Topics/StandardModernPrecision/Bids1C.hs
@@ -1,15 +1,5 @@
-module Topics.StandardModernPrecision.Bids(
-    firstSeatOpener
-  , oppsPass
-  -- Opening bids
-  , b1C
-  , b1D
-  , b1M
-  , b1N
-  , b2C
-  , b2D
-  , b2N
-  , b3N
+module Topics.StandardModernPrecision.Bids1C(
+    b1C  -- Copied from BasicBids
   -- Responses to 1C
   , b1C1D
   , b1C1H
@@ -53,115 +43,20 @@ module Topics.StandardModernPrecision.Bids(
   , b1C1D1S2N
   , b1C1D1S3S
   -- TODO: jumps and double jumps in MaFiA
-  -- syntactic sugar
-  , smpWrapN
-  , smpWrapS
 ) where
 
-import System.Random(StdGen)
-
-import Topic(wrap, Situations)
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, balancedHand, constrain, makeCall, makeAlertableCall,
-               makePass, alternatives, SuitLengthComparator(..),
-               compareSuitLength)
-import Situation(Situation, (<~))
-import CommonBids(cannotPreempt)
+               alternatives, SuitLengthComparator(..), compareSuitLength)
 import qualified Terminology as T
+import Topics.StandardModernPrecision.BasicBids(b1C, firstSeatOpener, oppsPass)
 
 
--- Because we're not using the Rule of 20 and its ilk, we're going to skip the
--- auctions that start with other folks passing for now, and maybe come back to
--- those later.
-firstSeatOpener :: Action
-firstSeatOpener = do
-    pointRange 11 40  -- Open any good 10 count, too. but that's hard to codify
-
-
-oppsPass :: Action
-oppsPass = do
-    cannotPreempt
-    makePass
-
-
-------------------
--- Opening bids --
-------------------
-b1N :: Action
-b1N = do
-    pointRange 14 16
-    balancedHand
-    makeAlertableCall (T.Bid 1 T.Notrump) "14-16"
-
-
-b2N :: Action
-b2N = do
-    pointRange 19 20  -- A modification from Part 1
-    balancedHand
-    makeCall $ T.Bid 2 T.Notrump
-
-
-b3N :: Action
-b3N = do
-    pointRange 24 40  -- Technically only 24-27, but close enough
-    balancedHand
-    makeCall $ T.Bid 3 T.Notrump
-
-
-b1C :: Action
-b1C = do
-    pointRange 16 40
-    sequence_ . map forbid $ [b1N, b2N, b3N]
-    makeAlertableCall (T.Bid 1 T.Clubs) "16+ HCP"
-
-
-b1M :: T.Suit -> Action
-b1M suit = do
-    forbid b1C
-    forbid b1N
-    minSuitLength suit 5
-    makeCall $ T.Bid 1 suit
-
-
-b2C :: Action
-b2C = do
-    forbid b1C
-    forbid (b1M T.Hearts)
-    forbid (b1M T.Spades)
-    minSuitLength T.Clubs 6
-    makeAlertableCall (T.Bid 2 T.Clubs) "6+ clubs"
-
-
-b2D :: Action
-b2D = do
-    forbid b1C
-    constrain "two_diamond_opener" ["shape(", ", 4414 + 4405 + 4315 + 3415)"]
-    makeAlertableCall (T.Bid 2 T.Diamonds) "4414, 4315, 3415, or 4405 shape"
-
-
-b1D :: Action
-b1D = do
-    sequence_ . map forbid $ [ b1C
-                             , b1N
-                             , b1M T.Hearts
-                             , b1M T.Spades
-                             , b2C
-                             , b2D
-                             ]
-    -- The next line is commented out because if it can be violated, we're gonna
-    -- have a bad day. Make sure that it's never violated in the results even if
-    -- it's not explicitly required.
-    --minSuitLength T.Diamonds 2
-    makeAlertableCall (T.Bid 1 T.Diamonds) "Could be as short as 2 diamonds"
-
-
----------------------
--- Responses to 1C --
----------------------
 b1C1D :: Action
 b1C1D = do
     pointRange 0 7
     makeAlertableCall (T.Bid 1 T.Diamonds) "0-7 HCP, any shape"
+
 
 _gameForcing :: Action
 _gameForcing = pointRange 8 11
@@ -515,18 +410,3 @@ b1C1D1S2C = do
     forbid b1C1D1S2D
     pointRange 6 7 -- Redundant with forbidding a 1N rebid, but explicit
     makeAlertableCall (T.Bid 2 T.Clubs) "6-7 HCP, at most 2 spades"
-
-
--------------------------------
--- Situation syntactic sugar --
--------------------------------
--- Always make opener be in first seat, until we figure out how to open in other
--- seats.
--- TODO: change this to let other folks be dealer, too
-smpWrapS :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
-            Situations
-smpWrapS sit = wrap $ sit <~ T.allVulnerabilities <~ [T.South]
-
-smpWrapN :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
-            Situations
-smpWrapN sit = wrap $ sit <~ T.allVulnerabilities <~ [T.North]

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -64,7 +64,7 @@ oneMajorMinor = let
         situation "1Mm" action (T.Bid 1 majorSuit) explanation
   in
     smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
-                          <~ T.minorSuits
+                        <~ T.minorSuits
 
 
 twoMinorSingle :: Situations
@@ -155,10 +155,10 @@ jumpBid = let
       in
         situation "J1" action rawBid explanation
   in
-    smpWrapS $ base sit <~ [ (T.Bid 2 T.Hearts,     B.b1C1D2H)
-                             , (T.Bid 2 T.Spades,   B.b1C1D2S)
-                             , (T.Bid 3 T.Clubs,    B.b1C1D3C)
-                             , (T.Bid 3 T.Diamonds, B.b1C1D3D)]
+    smpWrapS $ base sit <~ [ (T.Bid 2 T.Hearts,   B.b1C1D2H)
+                           , (T.Bid 2 T.Spades,   B.b1C1D2S)
+                           , (T.Bid 3 T.Clubs,    B.b1C1D3C)
+                           , (T.Bid 3 T.Diamonds, B.b1C1D3D)]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -7,7 +7,8 @@ import Auction(withholdBid, forbid, {-makePass, maxSuitLength, -} minSuitLength,
 import Situation(situation, base, (<~))
 --import CommonBids(cannotPreempt)
 import qualified Terminology as T
-import qualified Topics.StandardModernPrecision.Bids as B
+import Topics.StandardModernPrecision.BasicBids(smpWrapS)
+import qualified Topics.StandardModernPrecision.Bids1C as B
 
 
 notrump :: Situations
@@ -27,7 +28,7 @@ notrump = let
       in
         situation "xN" action (T.Bid level T.Notrump) explanation
   in
-    B.smpWrapS $ base sit <~ [(17, 18, 1), (21, 23, 2)]
+    smpWrapS $ base sit <~ [(17, 18, 1), (21, 23, 2)]
 
 
 oneMajor :: Situations
@@ -43,7 +44,7 @@ oneMajor = let
       in
         situation "1M" action (T.Bid 1 majorSuit) explanation
   in
-    B.smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
+    smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
 
 
 oneMajorMinor :: Situations
@@ -62,7 +63,7 @@ oneMajorMinor = let
       in
         situation "1Mm" action (T.Bid 1 majorSuit) explanation
   in
-    B.smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
+    smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
                           <~ T.minorSuits
 
 
@@ -80,7 +81,7 @@ twoMinorSingle = let
       in
         situation "2m" action (T.Bid 2 minorSuit) explanation
   in
-    B.smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 twoMinorMinors :: Situations
@@ -98,7 +99,7 @@ twoMinorMinors = let
       in
         situation "2mm" action (T.Bid 2 minorSuit) explanation
   in
-    B.smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 equalMinors :: Situations
@@ -117,7 +118,7 @@ equalMinors = let
       in
         situation "2me" action (T.Bid 2 T.Diamonds) explanation
   in
-    B.smpWrapS $ base sit
+    smpWrapS $ base sit
 
 
 bothMajorsLongSpades :: Situations
@@ -135,7 +136,7 @@ bothMajorsLongSpades = let
       in
         situation "2MS" action (T.Bid 1 T.Spades) explanation
   in
-    B.smpWrapS $ base sit
+    smpWrapS $ base sit
 
 
 jumpBid :: Situations
@@ -154,7 +155,7 @@ jumpBid = let
       in
         situation "J1" action rawBid explanation
   in
-    B.smpWrapS $ base sit <~ [ (T.Bid 2 T.Hearts,   B.b1C1D2H)
+    smpWrapS $ base sit <~ [ (T.Bid 2 T.Hearts,     B.b1C1D2H)
                              , (T.Bid 2 T.Spades,   B.b1C1D2S)
                              , (T.Bid 3 T.Clubs,    B.b1C1D3C)
                              , (T.Bid 3 T.Diamonds, B.b1C1D3D)]

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -27,7 +27,7 @@ notrump = let
       in
         situation "xN" action (T.Bid level T.Notrump) explanation
   in
-    B.smpWrapS $ base sit <~ [(17, 18, 1), (22, 24, 2)]
+    B.smpWrapS $ base sit <~ [(17, 18, 1), (21, 23, 2)]
 
 
 oneMajor :: Situations

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -5,7 +5,8 @@ import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, Action, suitLength, maxSuitLength)
 import Situation(Situation, situation, base, (<~))
 import qualified Terminology as T
-import qualified Topics.StandardModernPrecision.Bids as B
+import Topics.StandardModernPrecision.BasicBids(oppsPass, smpWrapN)
+import qualified Topics.StandardModernPrecision.Bids1C as B
 
 
 minSupport :: Situations
@@ -17,7 +18,7 @@ minSupport = let
         action = do
             B.startOfMafia
             openerBid
-            B.oppsPass
+            oppsPass
             withholdBid responderBid
         explanation _ =
             "With 4-card support and a minimum hand, raise partner's major.\
@@ -26,8 +27,8 @@ minSupport = let
       in
         situation "2M" action (T.Bid 2 suit) explanation
   in
-    B.smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2H, T.Hearts)
-                             , (B.b1C1D1S, B.b1C1D1S2S, T.Spades) ]
+    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2H, T.Hearts)
+                           , (B.b1C1D1S, B.b1C1D1S2S, T.Spades) ]
 
 
 maxSupportSemibalanced :: Situations
@@ -39,7 +40,7 @@ maxSupportSemibalanced = let
         action = do
             B.startOfMafia
             openerBid
-            B.oppsPass
+            oppsPass
             withholdBid responderBid
         explanation fmt =
             "With 4-card support and a maximum hand but no singleton, invite\
@@ -49,8 +50,8 @@ maxSupportSemibalanced = let
       in
         situation "3MB" action (T.Bid 3 suit) explanation
   in
-    B.smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H3H, T.Hearts)
-                             , (B.b1C1D1S, B.b1C1D1S3S, T.Spades) ]
+    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H3H, T.Hearts)
+                           , (B.b1C1D1S, B.b1C1D1S3S, T.Spades) ]
 
 
 maxSupportUnbalanced :: Situations
@@ -62,7 +63,7 @@ maxSupportUnbalanced = let
         action = do
             B.startOfMafia
             openerBid
-            B.oppsPass
+            oppsPass
             withholdBid responderBid
         explanation fmt =
             "With 4-card support, a maximum hand, and a singleton or void,\
@@ -76,8 +77,8 @@ maxSupportUnbalanced = let
       in
         situation "3MV" action (T.Bid 2 T.Notrump) explanation
   in
-    B.smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
-                             , (B.b1C1D1S, B.b1C1D1S2N) ]
+    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
+                           , (B.b1C1D1S, B.b1C1D1S2N) ]
 
 
 brakesHearts :: Situations
@@ -86,7 +87,7 @@ brakesHearts = let
         action = do
             B.startOfMafia
             B.b1C1D1H
-            B.oppsPass
+            oppsPass
             withholdBid B.b1C1D1H1N
         explanation fmt =
             "With neither major and a non-maximum hand, bid " ++
@@ -99,7 +100,7 @@ brakesHearts = let
       in
         situation "1NH" action (T.Bid 1 T.Notrump) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 brakesSpades :: Situations
@@ -108,7 +109,7 @@ brakesSpades = let
         action = do
             B.startOfMafia
             B.b1C1D1S
-            B.oppsPass
+            oppsPass
             maxSuitLength T.Hearts 4
             withholdBid B.b1C1D1S1N
         explanation fmt =
@@ -122,7 +123,7 @@ brakesSpades = let
       in
         situation "1NS" action (T.Bid 1 T.Notrump) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 brakesSpadesHearts :: Situations
@@ -131,7 +132,7 @@ brakesSpadesHearts = let
         action = do
             B.startOfMafia
             B.b1C1D1S
-            B.oppsPass
+            oppsPass
             suitLength T.Hearts 5
             withholdBid B.b1C1D1S1N
         explanation fmt =
@@ -148,7 +149,7 @@ brakesSpadesHearts = let
       in
         situation "1NSH" action (T.Bid 1 T.Notrump) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 otherMajorHearts :: Situations
@@ -157,7 +158,7 @@ otherMajorHearts = let
         action = do
             B.startOfMafia
             B.b1C1D1H
-            B.oppsPass
+            oppsPass
             withholdBid B.b1C1D1H1S
         explanation fmt =
             "With no support for partner's hearts but at least 4 spades,\
@@ -167,7 +168,7 @@ otherMajorHearts = let
       in
         situation "1S" action (T.Bid 1 T.Spades) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 otherMajorSpades :: Situations
@@ -176,7 +177,7 @@ otherMajorSpades = let
         action = do
             B.startOfMafia
             B.b1C1D1S
-            B.oppsPass
+            oppsPass
             withholdBid B.b1C1D1S2H
         explanation _ =
             "With a maximum hand, no support for partner's spades, but 5+\
@@ -189,7 +190,7 @@ otherMajorSpades = let
       in
         situation "2H" action (T.Bid 2 T.Hearts) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 threeCardSupport :: Situations
@@ -199,7 +200,7 @@ threeCardSupport = let
         action = do
             B.startOfMafia
             openerBid
-            B.oppsPass
+            oppsPass
             withholdBid responderBid
         explanation fmt =
             "With 3-card support and a non-minimum hand (5-7 HCP), bid " ++
@@ -211,8 +212,8 @@ threeCardSupport = let
       in
         situation "2D" action (T.Bid 2 T.Diamonds) explanation
   in
-    B.smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
-                             , (B.b1C1D1S, B.b1C1D1S2D) ]
+    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
+                           , (B.b1C1D1S, B.b1C1D1S2D) ]
 
 
 threeCardSupportHearts :: Situations
@@ -221,7 +222,7 @@ threeCardSupportHearts = let
         action = do
             B.startOfMafia
             B.b1C1D1S
-            B.oppsPass
+            oppsPass
             suitLength T.Hearts 5
             withholdBid B.b1C1D1S2D
         explanation fmt =
@@ -231,7 +232,7 @@ threeCardSupportHearts = let
       in
         situation "2D" action (T.Bid 2 T.Diamonds) explanation
   in
-    B.smpWrapN $ base sit
+    smpWrapN $ base sit
 
 
 maxNoMajors :: Situations
@@ -241,7 +242,7 @@ maxNoMajors = let
         action = do
             B.startOfMafia
             openerBid
-            B.oppsPass
+            oppsPass
             withholdBid responderBid
         explanation fmt =
             "With a maximum hand but no obvious major fit, respond " ++
@@ -254,8 +255,8 @@ maxNoMajors = let
       in
         situation "2C" action (T.Bid 2 T.Clubs) explanation
   in
-    B.smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
-                             , (B.b1C1D1S, B.b1C1D1S2C) ]
+    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
+                           , (B.b1C1D1S, B.b1C1D1S2C) ]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -5,7 +5,7 @@ import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid)
 import Situation(situation, base, (<~))
 import qualified Terminology as T
-import qualified Topics.StandardModernPrecision.Bids as B
+import qualified Topics.StandardModernPrecision.BasicBids as B
 
 
 oneClub :: Situations

--- a/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
+++ b/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
@@ -6,29 +6,30 @@ import Auction(withholdBid, forbid, maxSuitLength, makePass)
 import Situation(situation, base, (<~))
 import CommonBids(cannotPreempt)
 import qualified Terminology as T
-import qualified Topics.StandardModernPrecision.Bids as B
+import Topics.StandardModernPrecision.BasicBids(firstSeatOpener, oppsPass, b1C, smpWrapN, smpWrapS)
+import qualified Topics.StandardModernPrecision.Bids1C as B
 
 
 oneDiamond :: Situations
 oneDiamond = let
     action = do
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.b1C1D
     explanation fmt =
         "When game might not be possible opposite a random 17 HCP, start\
       \ with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ". This initiates MaFiA."
   in
-    B.smpWrapN . base $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
+    smpWrapN . base $ situation "1D" action (T.Bid 1 T.Diamonds) explanation
 
 
 oneHeart :: Situations
 oneHeart = let
     action = do
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.b1C1H
     explanation fmt =
         "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP,\
@@ -36,15 +37,15 @@ oneHeart = let
       \ Subsequent bids are natural 5-card suits (and later 4-card suits), not\
       \ MaFiA."
   in
-    B.smpWrapN . base $ situation "1H" action (T.Bid 1 T.Hearts) explanation
+    smpWrapN . base $ situation "1H" action (T.Bid 1 T.Hearts) explanation
 
 
 oneNotrump :: Situations
 oneNotrump = let
     action = do
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.b1C1N
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, and a balanced\
@@ -52,7 +53,7 @@ oneNotrump = let
         output fmt (T.Bid 1 T.Notrump) ++ ", and we'll\
       \ go from there. Stayman is on, but transfers are not."
   in
-    B.smpWrapN . base $ situation "1N" action (T.Bid 1 T.Notrump) explanation
+    smpWrapN . base $ situation "1N" action (T.Bid 1 T.Notrump) explanation
 
 
 slamSingleSuit :: Situations
@@ -66,9 +67,9 @@ slamSingleSuit = let
     sit strain = let
         level = if strain == T.Spades then 1 else 2
         action = do
-            B.firstSeatOpener
-            B.b1C
-            B.oppsPass
+            firstSeatOpener
+            b1C
+            oppsPass
             sequence_ . map (flip maxSuitLength 4) . filter (/= strain) $
                 T.allSuits
             withholdBid . finalAction $ strain
@@ -81,15 +82,15 @@ slamSingleSuit = let
       in
         situation "Slam" action (T.Bid level strain) explanation
   in
-    B.smpWrapN $ base sit <~ T.allSuits
+    smpWrapN $ base sit <~ T.allSuits
 
 
 twoSpades :: Situations
 twoSpades = let
     action = do
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.b1C2S
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, but an awkward\
@@ -101,7 +102,7 @@ twoSpades = let
         output fmt (T.Bid 4 T.Diamonds) ++ "/RKC to tell us what suit is trump\
       \ and how high they think we should go."
   in
-    B.smpWrapN . base $ situation "2S" action (T.Bid 2 T.Spades) explanation
+    smpWrapN . base $ situation "2S" action (T.Bid 2 T.Spades) explanation
 
 
 passGameSingleSuit :: Situations
@@ -115,14 +116,14 @@ passGameSingleSuit = let
     sit strain = let
         level = if any (== strain) T.majorSuits then 1 else 2
         action = do
-            forbid B.firstSeatOpener
+            forbid firstSeatOpener
             cannotPreempt
             makePass
-            forbid B.firstSeatOpener
-            B.oppsPass
-            B.firstSeatOpener
-            B.b1C
-            B.oppsPass
+            forbid firstSeatOpener
+            oppsPass
+            firstSeatOpener
+            b1C
+            oppsPass
             sequence_ . map (flip maxSuitLength 4) . filter (/= strain) $
                 T.allSuits
             withholdBid . finalAction $ strain
@@ -135,20 +136,20 @@ passGameSingleSuit = let
       in
         situation "PG" action (T.Bid level strain) explanation
   in
-    B.smpWrapS $ base sit <~ T.allSuits
+    smpWrapS $ base sit <~ T.allSuits
 
 
 passOneNotrump :: Situations
 passOneNotrump = let
     action = do
-        forbid B.firstSeatOpener
+        forbid firstSeatOpener
         cannotPreempt
         makePass
-        forbid B.firstSeatOpener
-        B.oppsPass
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        forbid firstSeatOpener
+        oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.bP1C1N
     explanation fmt =
         "You're a passed hand with game-forcing strength but no 5-card suit.\
@@ -159,20 +160,20 @@ passOneNotrump = let
       \ contract: better to be familiar and easy to remember than right-side\
       \ it, at least until we're more practiced with SMP."
   in
-    B.smpWrapS . base $ situation "P1N" action (T.Bid 1 T.Notrump) explanation
+    smpWrapS . base $ situation "P1N" action (T.Bid 1 T.Notrump) explanation
 
 
 passTwoSpades :: Situations
 passTwoSpades = let
     action = do
-        forbid B.firstSeatOpener
+        forbid firstSeatOpener
         cannotPreempt
         makePass
-        forbid B.firstSeatOpener
-        B.oppsPass
-        B.firstSeatOpener
-        B.b1C
-        B.oppsPass
+        forbid firstSeatOpener
+        oppsPass
+        firstSeatOpener
+        b1C
+        oppsPass
         withholdBid B.bP1C2S
     explanation fmt =
         "You're a passed hand with game-forcing strength, but an awkward\
@@ -185,7 +186,7 @@ passTwoSpades = let
         -- TODO: not sure this explanation is right; revisit it after you
         -- understand 4C/4D/RKC correctly
   in
-    B.smpWrapS . base $ situation "P2S" action (T.Bid 2 T.Spades) explanation
+    smpWrapS . base $ situation "P2S" action (T.Bid 2 T.Spades) explanation
 
 
 -- TODO: figure out how two-suited hands show slam interest. Which suit do you


### PR DESCRIPTION
Split the SMP bids into basic bids (openings and helpers) and bids over 1C. In the future, we'll have responses to 1D, 2C, etc. in their own separate files.

Other cleanup:
- 2N openings are 19-20 HCP, and thus opening 1C and then jumping to 2N is 21-23. 
- Fix typo that prevents compilation
- Precision openers must have at least Precision opening strength (whoops!)