### PR TITLE
Update base from 4.7 to at least 4.11

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ github:              "penguinland/bridge-practice"
 license:             BSD3
 author:              "Alan Davidson"
 maintainer:          "alan.davidson@gmail.com"
-copyright:           "2019 Alan Davidson"
+copyright:           "2019-2022 Alan Davidson"
 
 extra-source-files:
 - README.md
@@ -20,7 +20,7 @@ extra-source-files:
 description:         Please see the README on GitHub at <https://github.com/penguinland/bridge-practice#readme>
 
 dependencies:
-- base >= 4.7 && < 5
+- base >= 4.11 && < 5
 - containers
 - MissingH
 - process

--- a/src/Auction.hs
+++ b/src/Auction.hs
@@ -25,7 +25,7 @@ import Control.Monad.Trans.State.Strict(State, execState, get, put, modify)
 import Data.Bifunctor(first)
 import Data.List.Utils(join)
 
-import DealerProg(DealerProg, newDeal, addNewReq, addDefn, invert)
+import DealerProg(DealerProg, addNewReq, addDefn, invert)
 import Structures(Bidding, startBidding, (>-), currentBidder)
 import qualified Terminology as T
 
@@ -34,7 +34,7 @@ type Action = State Auction ()
 
 
 newAuction :: T.Direction -> Auction
-newAuction dealer = (startBidding dealer, newDeal)
+newAuction dealer = (startBidding dealer, mempty)
 
 
 finish :: T.Direction -> Action -> Auction

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -29,6 +29,7 @@ import qualified Terminology as T
 type CondName = String
 type CondDefn = String
 
+
 data DealerProg = DealerProg (Map.Map CondName CondDefn) [CondName]
 
 newDeal :: DealerProg
@@ -44,6 +45,7 @@ instance Semigroup DealerProg where
 instance Monoid DealerProg where
     mempty = newDeal
 
+
 addDefn :: CondName -> CondDefn -> DealerProg -> DealerProg
 addDefn name defn (DealerProg m l) =
   case Map.lookup name m of
@@ -51,15 +53,19 @@ addDefn name defn (DealerProg m l) =
     Just defn' -> if defn == defn' then DealerProg m l
                                    else error $ "2 defintions for " ++ name
 
+
 addReq :: CondName -> DealerProg -> DealerProg
 addReq expr (DealerProg m l) = DealerProg m (expr:l)
+
 
 addNewReq :: CondName -> CondDefn -> DealerProg -> DealerProg
 addNewReq name defn = addReq name . addDefn name defn
 
+
 invert :: DealerProg -> DealerProg
 invert (DealerProg defns reqs) =
     DealerProg defns ["!(" ++ join " && " reqs ++ ")"]
+
 
 toProgram :: DealerProg -> String
 toProgram (DealerProg defns conds) = join "\n" $

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -34,13 +34,14 @@ data DealerProg = DealerProg (Map.Map CondName CondDefn) [CondName]
 newDeal :: DealerProg
 newDeal = DealerProg Map.empty []
 
---instance Semigroup DealerProg where
-instance Monoid DealerProg where
-    mappend (DealerProg defnsA reqsA) (DealerProg defnsB reqsB) =
+instance Semigroup DealerProg where
+    (DealerProg defnsA reqsA) <> (DealerProg defnsB reqsB) =
         DealerProg (Map.unionWithKey noDupes defnsA defnsB) (reqsB ++ reqsA)
       where
         noDupes k a b | a == b    = a
                       | otherwise = error $ "2 definitons for " ++ k
+
+instance Monoid DealerProg where
     mempty = newDeal
 
 addDefn :: CondName -> CondDefn -> DealerProg -> DealerProg

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -1,6 +1,5 @@
 module DealerProg(
   DealerProg
-, newDeal
 , addDefn
 , addReq   -- TODO: does this need to be public?
 , addNewReq
@@ -32,8 +31,6 @@ type CondDefn = String
 
 data DealerProg = DealerProg (Map.Map CondName CondDefn) [CondName]
 
-newDeal :: DealerProg
-newDeal = DealerProg Map.empty []
 
 instance Semigroup DealerProg where
     (DealerProg defnsA reqsA) <> (DealerProg defnsB reqsB) =
@@ -43,7 +40,7 @@ instance Semigroup DealerProg where
                       | otherwise = error $ "2 definitons for " ++ k
 
 instance Monoid DealerProg where
-    mempty = newDeal
+    mempty = DealerProg Map.empty []
 
 
 addDefn :: CondName -> CondDefn -> DealerProg -> DealerProg

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -6,7 +6,6 @@ module ProblemSet(
 import Control.Monad.Trans.State.Strict(runState, get)
 import Data.List(sort)
 import Data.List.Utils(join, replace)
-import System.IO(readFile, writeFile)
 import System.Random(StdGen)
 
 import Output(toLatex)

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -6,6 +6,7 @@ module Situation (
 ) where
 
 
+import Data.Bifunctor(first)
 import System.Random(StdGen, genWord64R)
 
 import Auction(Action, finish)
@@ -40,13 +41,13 @@ instance Optionable Situation where
     (f <~ as) g = let
         -- We use Int, but StdGen uses Word64. Cast between them via Integer.
         maxIndex = fromInteger . toInteger . subtract 1 . length $ as
-        (i, g') = genWord64R maxIndex g
+        (i, g') = first (fromInteger . toInteger) . genWord64R maxIndex $ g
       in
-        f g' (as !! (fromInteger . toInteger $ i))
+        f g' (as !! i)
 
 instance (Optionable s) => Optionable (b -> s) where
     (f <~ as) g = let
         maxIndex = fromInteger . toInteger . subtract 1 . length $ as
-        (i, g') = genWord64R maxIndex g
+        (i, g') = first (fromInteger . toInteger) . genWord64R maxIndex $ g
       in
-        f g' (as !! (fromInteger . toInteger $ i))
+        f g' (as !! i)

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -39,12 +39,14 @@ class Optionable o where
 instance Optionable Situation where
     (f <~ as) g = let
         -- We use Int, but StdGen uses Word64. Cast between them via Integer.
-        (i, g') = genWord64R (fromInteger . toInteger . length $ as) g
+        maxIndex = fromInteger . toInteger . subtract 1 . length $ as
+        (i, g') = genWord64R maxIndex g
       in
         f g' (as !! (fromInteger . toInteger $ i))
 
 instance (Optionable s) => Optionable (b -> s) where
     (f <~ as) g = let
-        (i, g') = genWord64R (fromInteger . toInteger . length $ as) g
+        maxIndex = fromInteger . toInteger . subtract 1 . length $ as
+        (i, g') = genWord64R maxIndex g
       in
         f g' (as !! (fromInteger . toInteger $ i))

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -6,7 +6,7 @@ module Situation (
 ) where
 
 
-import System.Random(StdGen, next)
+import System.Random(StdGen, genWord64R)
 
 import Auction(Action, finish)
 import DealerProg(DealerProg)
@@ -38,14 +38,13 @@ class Optionable o where
 
 instance Optionable Situation where
     (f <~ as) g = let
-        (n, g') = next g
-        i = n `mod` length as :: Int
+        -- We use Int, but StdGen uses Word64. Cast between them via Integer.
+        (i, g') = genWord64R (fromInteger . toInteger . length $ as) g
       in
-        f g' (as !! i)
+        f g' (as !! (fromInteger . toInteger $ i))
 
 instance (Optionable s) => Optionable (b -> s) where
     (f <~ as) g = let
-        (n, g') = next g
-        i = n `mod` length as :: Int
+        (i, g') = genWord64R (fromInteger . toInteger . length $ as) g
       in
-        f g' (as !! i)
+        f g' (as !! (fromInteger . toInteger $ i))

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -7,7 +7,8 @@ module SituationInstance (
 
 import Control.Monad.Trans.State.Strict(State)
 import Data.List.Utils(join)
-import System.Random(StdGen, next)
+import Data.Bifunctor(first)
+import System.Random(StdGen, genWord64)
 
 import DealerProg(eval)
 import Output(Showable, toLatex, OutputType(..), Commentary)
@@ -36,7 +37,7 @@ instance Showable SituationInstance where
 instantiate :: String -> Situation ->
         State StdGen (IO (Maybe SituationInstance))
 instantiate reference (Situation _ b dl c s v dn) = do
-    n <- use next
+    n <- use (first (fromInteger . toInteger) . genWord64)
     let instantiate' :: IO (Maybe SituationInstance)
         instantiate' = do
             maybeDeal <- eval dn v dl n

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -6,8 +6,8 @@ module SituationInstance (
 
 
 import Control.Monad.Trans.State.Strict(State)
-import Data.List.Utils(join)
 import Data.Bifunctor(first)
+import Data.List.Utils(join)
 import System.Random(StdGen, genWord64)
 
 import DealerProg(eval)

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -9,7 +9,7 @@ module Topic(
 
 import Control.Monad.Trans.State.Strict(State)
 import Data.Bifunctor(first)
-import System.Random(RandomGen, StdGen, next, split, mkStdGen)
+import System.Random(RandomGen, StdGen, genWord64, split, mkStdGen)
 
 import Random(use, pickItem)
 import Situation(Situation, base, (<~))
@@ -23,7 +23,7 @@ class Randomizer r where
     make :: RandomGen g => g -> (r, g)
 
 instance Randomizer StdGen where
-    make = first mkStdGen . next
+    make = first (mkStdGen . fromInteger . toInteger) . genWord64
 
 
 data Situations = RawSit Situation

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,8 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-11.22
+#resolver: lts-11.22
+resolver: lts-20.1
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 527836
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/11/22.yaml
-    sha256: 341870ac98d8a9f8f77c4adf2e9e0b22063e264a7fbeb4c85b7af5f380dac60e
-  original: lts-11.22
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1


### PR DESCRIPTION
After merging this commit, I suggest you delete `.stack-work/`, so the whole thing gets re-generated next time you run `run.sh`. The `run.sh` script has a slight brittleness, in which it assumes you've only compiled against one version of cabal, and this PR updates to a new version. 

The goal here is to get the declaration `Semigroup a => Monoid (Maybe a)`, which was added in `base` version 4.11 (released in March 2018). This will be used in the implementation of extracting the last call from an auction. Grabbing the last call from an auction will be useful when displaying self-alerts for the intended calls in the solutions: rather than describing the alerts in two places (once when making bids in an auction and once when specifying the solutions to the situations), we can just put them in the auctions, and extract them later to show the solutions with the descriptions of alerts. but first, this all requires upgrading `base` to at least 4.11. and doing that required upgrading the resolver to something new enough that it knows about base 4.11, so I set it to the latest update (LTS-20.1). 

and then while I was looking at it, I replaced `newDeal` with `mempty`, since the `DealerProg` datatype is a `Monoid`.