### PR TITLE
Refactor situations to use the State monad

### DIFF
--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -1,7 +1,6 @@
 module Situation (
   Situation(..)
 , situation
-, base
 , (<~)
 ) where
 
@@ -34,7 +33,3 @@ situation r a c s v d = Situation r bidding deal answer s v d
 
 (<~) :: (State StdGen (a -> b)) -> [a] -> State StdGen b
 sf <~ as = sf <*> (pickItem as)
-
-
-base :: a -> State StdGen a
-base = return

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -18,7 +18,7 @@ import Control.Monad.Trans.State.Strict(State)
 import System.Random(StdGen)
 
 import Random(pickItem)
-import Situation(Situation, base, (<~))
+import Situation(Situation, (<~))
 import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities)
 
 
@@ -47,7 +47,7 @@ wrapVulDlr sit = wrap $ sit <~ allVulnerabilities <~ allDirections
 -- and more syntactic sugar for a Situation that is _only_ parameterized on
 -- those features.
 stdWrap :: (Vulnerability -> Direction -> Situation) -> Situations
-stdWrap = wrapVulDlr . base
+stdWrap = wrapVulDlr . return
 
 
 data Topic = Topic {topicName :: String

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -15,16 +15,15 @@ module Topic(
 
 import Control.Monad(liftM)
 import Control.Monad.Trans.State.Strict(State)
-import System.Random(StdGen, split)
+import System.Random(StdGen)
 
-import Random(use, pickItem)
+import Random(pickItem)
 import Situation(Situation, base, (<~))
 import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities)
 
 
 data Situations = RawSit Situation
                 | SitList [Situations]
-                | SitFun (StdGen -> Situations)
                 | SitState (State StdGen Situations)
 
 
@@ -35,8 +34,6 @@ instance Situationable Situation where
     wrap = RawSit
 instance (Situationable s) => Situationable [s] where
     wrap = SitList . map wrap
-instance (Situationable s) => Situationable (StdGen -> s) where
-    wrap f = SitFun (\g -> wrap $ f g)
 instance (Situationable s) => Situationable (State StdGen s) where
     wrap = SitState . liftM wrap
 instance Situationable Situations where
@@ -63,5 +60,4 @@ choose = choose' . topicSituations
   where
     choose' (RawSit s)   = return s
     choose' (SitList ss) = pickItem ss >>= choose'
-    choose' (SitFun f)   = use split >>= (choose' . f)
     choose' (SitState f) = f >>= choose'

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -45,7 +45,7 @@ instance Situationable Situations where
 
 -- The most common Situation parameters are letting anyone be the dealer and
 -- letting anyone be vulnerable. Make some syntactic sugar for that.
-wrapVulDlr :: (StdGen -> Vulnerability -> Direction -> Situation) -> Situations
+wrapVulDlr :: (State StdGen (Vulnerability -> Direction -> Situation)) -> Situations
 wrapVulDlr sit = wrap $ sit <~ allVulnerabilities <~ allDirections
 -- and more syntactic sugar for a Situation that is _only_ parameterized on
 -- those features.

--- a/src/Topics/JacobyTransfers.hs
+++ b/src/Topics/JacobyTransfers.hs
@@ -4,7 +4,7 @@ import Output(output, Punct(NDash))
 import Topic(Topic(..), Situations, wrap, stdWrap, wrapVulDlr)
 import Auction(forbid, makeCall, makeAlertableCall, makePass, pointRange,
                suitLength, minSuitLength, Action, balancedHand, constrain)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
 
@@ -107,7 +107,7 @@ initiateTransferWeak = let
       in
         situation "InitWeak" action bid explanation
   in
-    wrapVulDlr $ base sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 initiateTransferBInv :: Situations
@@ -130,7 +130,7 @@ initiateTransferBInv = let
       in
         situation "InitBInv" action bid explanation
   in
-    wrapVulDlr $ base sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 initiateTransferBGf :: Situations
@@ -154,7 +154,7 @@ initiateTransferBGf = let
       in
         situation "InitBGF" action bid explanation
   in
-    wrapVulDlr $ base sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 completeTransfer :: Situations
@@ -172,7 +172,7 @@ completeTransfer = let
       in
         situation "Complete" action bid explanation
   in
-    wrapVulDlr $ base sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 completeTransferShort :: Situations
@@ -195,7 +195,7 @@ completeTransferShort = let
       in
         situation "Short" action bid explanation
   in
-    wrapVulDlr $ base sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 majors55inv :: Situations
@@ -248,7 +248,7 @@ majors55gf = let
     -- Note that with 5-5 and game-going strength, you would have opened the
     -- bidding if you had a chance. So, you must not have had a chance to bid
     -- before your partner.
-    wrap $ base sit <~ T.allVulnerabilities <~ [T.West, T.North]
+    wrap $ return sit <~ T.allVulnerabilities <~ [T.West, T.North]
 
 
 topic :: Topic

--- a/src/Topics/MinorTransfersScott.hs
+++ b/src/Topics/MinorTransfersScott.hs
@@ -5,7 +5,7 @@ import Topic(Topic(..), Situations, wrap)
 import Auction(forbid, makeCall, makeAlertableCall, makePass, pointRange,
                hasTopN, constrain, minSuitLength, maxSuitLength, Action,
                balancedHand, withholdBid)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
 
@@ -94,7 +94,8 @@ initiateTransfer = let
       in
         situation "Init" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.West, T.North]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.West, T.North]
 
 
 completeTransfer :: Situations
@@ -113,7 +114,8 @@ completeTransfer = let
       in
         situation "Complete" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
 
 
 superacceptTransfer :: Situations
@@ -135,7 +137,8 @@ superacceptTransfer = let
       in
         situation "SupAcc" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
 
 
 completeSuperacceptAKQ :: Situations
@@ -157,7 +160,8 @@ completeSuperacceptAKQ = let
       in
         situation "3NTAKQ" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 completeSuperacceptKQJ10 :: Situations
@@ -181,7 +185,8 @@ completeSuperacceptKQJ10 = let
       in
         situation "3NTKQJ" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 completeSuperaccept10CardFit :: Situations
@@ -203,7 +208,8 @@ completeSuperaccept10CardFit = let
       in
         situation "3NT10Fit" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 failSuperaccept :: Situations
@@ -226,7 +232,8 @@ failSuperaccept = let
       in
         situation "SupFail" action bid explanation
   in
-    wrap $ base sit <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrap $ return sit
+        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 notrumpInvite :: Situations
@@ -255,7 +262,7 @@ notrumpInvite = let
       in
         situation "NTInv" action bid explanation
   in
-    wrap $ base sit <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/BasicBids.hs
+++ b/src/Topics/StandardModernPrecision/BasicBids.hs
@@ -15,6 +15,7 @@ module Topics.StandardModernPrecision.BasicBids(
   , smpWrapS
 ) where
 
+import Control.Monad.Trans.State.Strict(State)
 import System.Random(StdGen)
 
 import Topic(wrap, Situations)
@@ -124,10 +125,10 @@ b1D = do
 -- Always make opener be in first seat, until we figure out how to open in other
 -- seats.
 -- TODO: change this to let other folks be dealer, too
-smpWrapS :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
+smpWrapS :: (State StdGen (T.Vulnerability -> T.Direction -> Situation)) ->
             Situations
 smpWrapS sit = wrap $ sit <~ T.allVulnerabilities <~ [T.South]
 
-smpWrapN :: (StdGen -> T.Vulnerability -> T.Direction -> Situation) ->
+smpWrapN :: (State StdGen (T.Vulnerability -> T.Direction -> Situation)) ->
             Situations
 smpWrapN sit = wrap $ sit <~ T.allVulnerabilities <~ [T.North]

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -4,7 +4,7 @@ import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, forbid, minSuitLength, suitLength, balancedHand,
                SuitLengthComparator(..), compareSuitLength, extractLastCall)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(smpWrapS)
 import qualified Topics.StandardModernPrecision.Bids1C as B
@@ -23,7 +23,7 @@ notrump = let
       in
         situation "xN" action bid explanation
   in
-    smpWrapS $ base sit <~ [B.b1C1D1N, B.b1C1D2N]
+    smpWrapS $ return sit <~ [B.b1C1D1N, B.b1C1D2N]
 
 
 oneMajor :: Situations
@@ -39,7 +39,7 @@ oneMajor = let
       in
         situation "1M" action bid explanation
   in
-    smpWrapS $ base sit <~ [B.b1C1D1H, B.b1C1D1S]
+    smpWrapS $ return sit <~ [B.b1C1D1H, B.b1C1D1S]
 
 
 oneMajorMinor :: Situations
@@ -58,8 +58,8 @@ oneMajorMinor = let
       in
         situation "1Mm" action bid explanation
   in
-    smpWrapS $ base sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
-                        <~ T.minorSuits
+    smpWrapS $ return sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
+                          <~ T.minorSuits
 
 
 twoMinorSingle :: Situations
@@ -76,7 +76,7 @@ twoMinorSingle = let
       in
         situation "2m" action bid explanation
   in
-    smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    smpWrapS $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 twoMinorMinors :: Situations
@@ -94,7 +94,7 @@ twoMinorMinors = let
       in
         situation "2mm" action bid explanation
   in
-    smpWrapS $ base sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    smpWrapS $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 equalMinors :: Situations
@@ -113,7 +113,7 @@ equalMinors = let
       in
         situation "2me" action B.b1C1D2D explanation
   in
-    smpWrapS $ base sit
+    smpWrapS $ return sit
 
 
 bothMajorsLongSpades :: Situations
@@ -131,7 +131,7 @@ bothMajorsLongSpades = let
       in
         situation "2MS" action B.b1C1D1S explanation
   in
-    smpWrapS $ base sit
+    smpWrapS $ return sit
 
 
 jumpBid :: Situations
@@ -150,7 +150,7 @@ jumpBid = let
       in
         situation "J1" action bid explanation
   in
-    smpWrapS $ base sit <~ [B.b1C1D2H, B.b1C1D2S, B.b1C1D3C, B.b1C1D3D]
+    smpWrapS $ return sit <~ [B.b1C1D2H, B.b1C1D2S, B.b1C1D3C, B.b1C1D3D]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -3,7 +3,7 @@ module Topics.StandardModernPrecision.MafiaResponses(topic) where
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, Action, suitLength, maxSuitLength)
-import Situation(Situation, situation, base, (<~))
+import Situation(Situation, situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(oppsPass, smpWrapN)
 import qualified Topics.StandardModernPrecision.Bids1C as B
@@ -27,8 +27,8 @@ minSupport = let
       in
         situation "2M" action responderBid explanation
   in
-    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2H)
-                           , (B.b1C1D1S, B.b1C1D1S2S) ]
+    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2H)
+                             , (B.b1C1D1S, B.b1C1D1S2S) ]
 
 
 maxSupportSemibalanced :: Situations
@@ -50,8 +50,8 @@ maxSupportSemibalanced = let
       in
         situation "3MB" action responderBid explanation
   in
-    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H3H)
-                           , (B.b1C1D1S, B.b1C1D1S3S) ]
+    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H3H)
+                             , (B.b1C1D1S, B.b1C1D1S3S) ]
 
 
 maxSupportUnbalanced :: Situations
@@ -77,8 +77,8 @@ maxSupportUnbalanced = let
       in
         situation "3MV" action responderBid explanation
   in
-    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
-                           , (B.b1C1D1S, B.b1C1D1S2N) ]
+    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
+                             , (B.b1C1D1S, B.b1C1D1S2N) ]
 
 
 brakesHearts :: Situations
@@ -100,7 +100,7 @@ brakesHearts = let
       in
         situation "1NH" action B.b1C1D1H1N explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 brakesSpades :: Situations
@@ -123,7 +123,7 @@ brakesSpades = let
       in
         situation "1NS" action B.b1C1D1S1N explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 brakesSpadesHearts :: Situations
@@ -149,7 +149,7 @@ brakesSpadesHearts = let
       in
         situation "1NSH" action B.b1C1D1S1N explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 otherMajorHearts :: Situations
@@ -168,7 +168,7 @@ otherMajorHearts = let
       in
         situation "1S" action B.b1C1D1H1S explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 otherMajorSpades :: Situations
@@ -190,7 +190,7 @@ otherMajorSpades = let
       in
         situation "2H" action B.b1C1D1S2H explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 threeCardSupport :: Situations
@@ -212,7 +212,7 @@ threeCardSupport = let
       in
         situation "2D" action responderBid explanation
   in
-    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
+    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
                            , (B.b1C1D1S, B.b1C1D1S2D) ]
 
 
@@ -232,7 +232,7 @@ threeCardSupportHearts = let
       in
         situation "2D" action B.b1C1D1S2D explanation
   in
-    smpWrapN $ base sit
+    smpWrapN $ return sit
 
 
 maxNoMajors :: Situations
@@ -255,8 +255,8 @@ maxNoMajors = let
       in
         situation "2C" action responderBid explanation
   in
-    smpWrapN $ base sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
-                           , (B.b1C1D1S, B.b1C1D1S2C) ]
+    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
+                             , (B.b1C1D1S, B.b1C1D1S2C) ]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -3,7 +3,7 @@ module Topics.StandardModernPrecision.OpeningBids(topic) where
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified Topics.StandardModernPrecision.BasicBids as B
 
@@ -17,7 +17,7 @@ oneClub = let
         "With 16 or more points (17 or more when balanced), open a strong " ++
         output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of SMP."
   in
-    B.smpWrapS . base $ situation "1C" action B.b1C explanation
+    B.smpWrapS . return $ situation "1C" action B.b1C explanation
 
 
 oneDiamond :: Situations
@@ -29,7 +29,7 @@ oneDiamond = let
         "With opening strength but the wrong strength/shape for any other\
       \ opening bid, start with " ++ output fmt (T.Bid 1 T.Diamonds) ++ "."
   in
-    B.smpWrapS . base $ situation "1D" action B.b1D explanation
+    B.smpWrapS . return $ situation "1D" action B.b1D explanation
 
 
 oneMajor :: Situations
@@ -47,7 +47,7 @@ oneMajor = let
         situation "1M" action (B.b1M suit) explanation
   in
     -- TODO: figure out some syntactic sugar for this, too
-    B.smpWrapS $ base sit <~ T.majorSuits
+    B.smpWrapS $ return sit <~ T.majorSuits
 
 
 oneNotrump :: Situations
@@ -59,7 +59,7 @@ oneNotrump = let
         "With a balanced hand and 14-16 HCP, open " ++
         output fmt (T.Bid 1 T.Notrump) ++ "."
   in
-    B.smpWrapS . base $ situation "1N" action B.b1N explanation
+    B.smpWrapS . return $ situation "1N" action B.b1N explanation
 
 
 twoClubs :: Situations
@@ -72,7 +72,7 @@ twoClubs = let
        \ hand strong enough to open " ++ output fmt (T.Bid 1 T.Clubs) ++ ",\
        \ open " ++ output fmt (T.Bid 2 T.Clubs) ++ "."
   in
-    B.smpWrapS . base $ situation "2C" action B.b2C explanation
+    B.smpWrapS . return $ situation "2C" action B.b2C explanation
 
 
 twoDiamonds :: Situations
@@ -85,7 +85,7 @@ twoDiamonds = let
        \ hand without diamonds, which can be thought of as a 14-card hand with\
        \ 4415 shape but missing any single card."
   in
-    B.smpWrapS . base $ situation "2D" action B.b2D explanation
+    B.smpWrapS . return $ situation "2D" action B.b2D explanation
 
 
 twoNotrump :: Situations
@@ -97,7 +97,7 @@ twoNotrump = let
         "With a balanced hand and 19 to a bad 21 HCP, open " ++
         output fmt (T.Bid 2 T.Notrump) ++ "."
   in
-    B.smpWrapS . base $ situation "2N" action B.b2N explanation
+    B.smpWrapS . return $ situation "2N" action B.b2N explanation
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
+++ b/src/Topics/StandardModernPrecision/ResponsesToStrongClub.hs
@@ -3,7 +3,7 @@ module Topics.StandardModernPrecision.ResponsesToStrongClub(topic) where
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, forbid, maxSuitLength, makePass)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import CommonBids(cannotPreempt)
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(firstSeatOpener, oppsPass, b1C, smpWrapN, smpWrapS)
@@ -21,7 +21,7 @@ oneDiamond = let
         "When game might not be possible opposite a random 17 HCP, start\
       \ with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ". This initiates MaFiA."
   in
-    smpWrapN . base $ situation "1D" action B.b1C1D explanation
+    smpWrapN . return $ situation "1D" action B.b1C1D explanation
 
 
 oneHeart :: Situations
@@ -37,7 +37,7 @@ oneHeart = let
       \ Subsequent bids are natural 5-card suits (and later 4-card suits), not\
       \ MaFiA."
   in
-    smpWrapN . base $ situation "1H" action B.b1C1H explanation
+    smpWrapN . return $ situation "1H" action B.b1C1H explanation
 
 
 oneNotrump :: Situations
@@ -53,7 +53,7 @@ oneNotrump = let
         output fmt (T.Bid 1 T.Notrump) ++ ", and we'll\
       \ go from there. Stayman is on, but transfers are not."
   in
-    smpWrapN . base $ situation "1N" action B.b1C1N explanation
+    smpWrapN . return $ situation "1N" action B.b1C1N explanation
 
 
 slamSingleSuit :: Situations
@@ -83,7 +83,7 @@ slamSingleSuit = let
       in
         situation "Slam" action bid explanation
   in
-    smpWrapN $ base sit <~ T.allSuits
+    smpWrapN $ return sit <~ T.allSuits
 
 
 twoSpades :: Situations
@@ -104,7 +104,7 @@ twoSpades = let
         output fmt (T.Bid 4 T.Diamonds) ++ "/RKC to tell us how high to go and\
       \ what suit is trump."
   in
-    smpWrapN . base $ situation "2S" action B.b1C2S explanation
+    smpWrapN . return $ situation "2S" action B.b1C2S explanation
 
 
 passGameSingleSuit :: Situations
@@ -139,7 +139,7 @@ passGameSingleSuit = let
       in
         situation "PG" action bid explanation
   in
-    smpWrapS $ base sit <~ T.allSuits
+    smpWrapS $ return sit <~ T.allSuits
 
 
 passOneNotrump :: Situations
@@ -162,7 +162,7 @@ passOneNotrump = let
       \ go from there. Stayman is on, but transfers are off (so the stronger\
       \ hand will be declarer more often)."
   in
-    smpWrapS . base $ situation "P1N" action B.bP1C1N explanation
+    smpWrapS . return $ situation "P1N" action B.bP1C1N explanation
 
 
 passTwoSpades :: Situations
@@ -188,7 +188,7 @@ passTwoSpades = let
         output fmt (T.Bid 4 T.Diamonds) ++ "/RKC to indicate how high to go\
       \ and which suit is trump."
   in
-    smpWrapS . base $ situation "P2S" action B.bP1C2S explanation
+    smpWrapS . return $ situation "P2S" action B.bP1C2S explanation
 
 
 -- TODO: figure out how two-suited hands show slam interest. Which suit do you

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -5,7 +5,7 @@ import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, alternatives, constrain, makePass, makeCall,
                makeAlertableCall, withholdBid)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
 
@@ -126,7 +126,7 @@ immediateSignoffSpades5 = let
     -- deals, and generating those hands is difficult for dealer (often
     -- requiring over 1,000,000 hands to be generated). Consequently, we limit
     -- these situations to times when East isn't dealer.
-    wrap $ base sit <~ T.allVulnerabilities <~ [T.North, T.South, T.West]
+    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.South, T.West]
 
 
 passSignoff2Spades :: Situations
@@ -152,7 +152,7 @@ passSignoff2Spades = let
       in
         situation "2SP" action (makeCall T.Pass) explanation
   in
-    wrapVulDlr $ base sit <~ [3, 4]
+    wrapVulDlr $ return sit <~ [3, 4]
 
 
 immediateSignoffClubs :: Situations
@@ -250,7 +250,7 @@ correctSignoffHearts = let
   in
     -- We want to commonly show times when responder has just 3 hearts (and
     -- we're avoiding a 3-3 fit) and times when responder has a real heart suit.
-    wrapVulDlr $ base sit <~ [3, 6]
+    wrapVulDlr $ return sit <~ [3, 6]
 
 
 topic :: Topic

--- a/src/Topics/StandardOpeners.hs
+++ b/src/Topics/StandardOpeners.hs
@@ -3,7 +3,7 @@ module Topics.StandardOpeners(topic) where
 import Output(output)
 import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
 import Auction(forbid, suitLength, minSuitLength, maxSuitLength, withholdBid)
-import Situation(situation, base, (<~))
+import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
 import qualified StandardOpenings as SO
@@ -161,7 +161,7 @@ oneClubEqualMinors = let
       in
         situation "1C1Suit" action SO.b1c explanation
   in
-    wrapVulDlr $ base sit <~ [3, 4]
+    wrapVulDlr $ return sit <~ [3, 4]
 
 
 bothMinorsNoReverse :: Situations


### PR DESCRIPTION
The implementation of `<~` has never sat well with me, and this is a first attempt at cleaning it up a bit. You can now `wrap` a `State StdGen Situation` into a `Situations`, and can no longer do it with a `StdGen -> Situation`. This greatly simplifies `<~`, which now operates on `State StdGen (a -> b)` and gets rid of the `Optionable` typeclass entirely. Alas, I was hoping to simplify the `wrapVulDlr $ base sit` in the definition of each `Situation`, but still can't find a way to do that.

I could go through and replace all mention of `base` with `return`; is it worth the hassle? Probably.