### PR TITLE
Immediate responses to SMP 1D openings

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,22 +4,24 @@ import System.Random(mkStdGen)
 --import qualified Topics.MinorTransfersScott as MinorTransfers
 --import qualified Topics.StandardOpeners as StandardOpeners
 
-import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
-import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
-import qualified Topics.StandardModernPrecision.Mafia as Mafia
-import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
-import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
+--import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
+--import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
+--import qualified Topics.StandardModernPrecision.Mafia as Mafia
+--import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
+--import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
+import qualified Topics.StandardModernPrecision.OneDiamondResponses as OneDResponses
 
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
 main = let
-    topics = [ SmpOpenings.topic
-             , Smp1CResponses.topic
-             , Mafia.topic
-             , MafiaResponses.topic
-             , TwoDOpen.topic
+    topics = [ --SmpOpenings.topic
+             --, Smp1CResponses.topic
+             --, Mafia.topic
+             --, MafiaResponses.topic
+             --, TwoDOpen.topic
+             OneDResponses.topic
              ]
   in do
     outputLatex 100 topics "test" (mkStdGen 0)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ import System.Random(mkStdGen)
 --import qualified Topics.StandardOpeners as StandardOpeners
 
 import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
-import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
+import qualified Topics.StandardModernPrecision.OneClubResponses as Smp1CResponses
 import qualified Topics.StandardModernPrecision.OneDiamondResponses as Smp1DResponses
 import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,24 +4,24 @@ import System.Random(mkStdGen)
 --import qualified Topics.MinorTransfersScott as MinorTransfers
 --import qualified Topics.StandardOpeners as StandardOpeners
 
---import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
---import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
---import qualified Topics.StandardModernPrecision.Mafia as Mafia
---import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
---import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDOpen
-import qualified Topics.StandardModernPrecision.OneDiamondResponses as OneDResponses
+import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
+import qualified Topics.StandardModernPrecision.ResponsesToStrongClub as Smp1CResponses
+import qualified Topics.StandardModernPrecision.OneDiamondResponses as Smp1DResponses
+import qualified Topics.StandardModernPrecision.Mafia as Mafia
+import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
+import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
 main = let
-    topics = [ --SmpOpenings.topic
-             --, Smp1CResponses.topic
-             --, Mafia.topic
-             --, MafiaResponses.topic
-             --, TwoDOpen.topic
-             OneDResponses.topic
+    topics = [ SmpOpenings.topic
+             , Smp1CResponses.topic
+             , Mafia.topic
+             , MafiaResponses.topic
+             , Smp1DResponses.topic
+             , Smp2DOpen.topic
              ]
   in do
     outputLatex 100 topics "test" (mkStdGen 0)

--- a/src/Auction.hs
+++ b/src/Auction.hs
@@ -20,6 +20,7 @@ module Auction (
 , compareSuitLength
 , SuitLengthComparator(..)
 , extractLastCall
+, displayLastCall
 ) where
 
 import Control.Monad.Trans.State.Strict(State, execState, get, put, modify)
@@ -27,6 +28,7 @@ import Data.Bifunctor(first)
 import Data.List.Utils(join)
 
 import DealerProg(DealerProg, addNewReq, addDefn, invert)
+import Output(output, OutputType)
 import Structures(Bidding, startBidding, (>-), lastCall, currentBidder)
 import qualified Terminology as T
 
@@ -150,5 +152,10 @@ extractLastCall =
     -- It doesn't matter who was dealer: use North just to extract the bidding
     -- from the action.
     lastCall . fst . finish T.North
+
+-- displayLastCall is for use in explanations: it formats the most recent call
+-- from an action while stripping out any alerts it might have
+displayLastCall :: OutputType -> Action -> String
+displayLastCall fmt = output fmt . T.extractCall . extractLastCall
 
 -- TODO: hasCard

--- a/src/Auction.hs
+++ b/src/Auction.hs
@@ -156,6 +156,6 @@ extractLastCall =
 -- displayLastCall is for use in explanations: it formats the most recent call
 -- from an action while stripping out any alerts it might have
 displayLastCall :: OutputType -> Action -> String
-displayLastCall fmt = output fmt . T.extractCall . extractLastCall
+displayLastCall fmt = output fmt . T.removeAlert . extractLastCall
 
 -- TODO: hasCard

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -66,7 +66,15 @@ invert (DealerProg defns reqs) =
 
 toProgram :: DealerProg -> String
 toProgram (DealerProg defns conds) = join "\n" $
-    ["generate 1000000", "produce 1", ""] ++
+    -- This used to generate 1 million boards, but some situations are extremely
+    -- rare (e.g., North opens a Precision 1D with 5 hearts and South responds
+    -- 2N: occurs less than twice in a million deals), and if you run the dealer
+    -- program many times, it'll fail at least once. So, this was bumped up to
+    -- 10 million so that it should really only fail if the constraints are
+    -- impossible, rather than just a really rare situation. If 10 million still
+    -- isn't enough, consider removing those situations from practice entirely,
+    -- since they'll probably never come up.
+    ["generate 10000000", "produce 1", ""] ++
     Map.foldMapWithKey formatDefinition defns
     ++ ["", "condition",
         "    " ++ (join " && " . map conditionToString . reverse $ conds),

--- a/src/Terminology.hs
+++ b/src/Terminology.hs
@@ -8,6 +8,7 @@ module Terminology (
 , majorSuits
 , Call(..)
 , CompleteCall(..)
+, extractCall
 , Vulnerability(..)
 , allVulnerabilities
 ) where
@@ -101,6 +102,10 @@ data CompleteCall = CompleteCall Call (Maybe String)
 instance Showable CompleteCall where
     toLatex (CompleteCall c a) =
         toLatex c ++ maybe "" (\x -> " (" ++ x ++ ")") a
+
+
+extractCall :: CompleteCall -> Call
+extractCall (CompleteCall c _) = c
 
 
 data Vulnerability = NS | EW | Both | None deriving Eq

--- a/src/Terminology.hs
+++ b/src/Terminology.hs
@@ -8,7 +8,7 @@ module Terminology (
 , majorSuits
 , Call(..)
 , CompleteCall(..)
-, extractCall
+, removeAlert
 , Vulnerability(..)
 , allVulnerabilities
 ) where
@@ -104,8 +104,8 @@ instance Showable CompleteCall where
         toLatex c ++ maybe "" (\x -> " (" ++ x ++ ")") a
 
 
-extractCall :: CompleteCall -> Call
-extractCall (CompleteCall c _) = c
+removeAlert :: CompleteCall -> Call
+removeAlert (CompleteCall c _) = c
 
 
 data Vulnerability = NS | EW | Both | None deriving Eq

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -9,11 +9,14 @@ module Topics.StandardModernPrecision.Bids1D(
   , b1D2S
   , b1D2N
   , b1D3C
---  , b1D3D
+  , b1D3D
 --  , b1D3H
 --  , b1D3S
   , b1D3N
   , b1D4C
+--  , b1D4D
+--  , b1D4H
+--  , b1D4S
 ) where
 
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
@@ -126,6 +129,16 @@ b1D3C = do
     mapM_ (`maxSuitLength` 3) T.majorSuits
     makeAlertableCall (T.Bid 3 T.Clubs)
         "5-4 or 4-5 in the minors, less than invitational strength"
+
+
+b1D3D :: Action
+b1D3D = do
+    pointRange 6 10
+    minSuitLength T.Diamonds 6
+    -- With 8+ diamonds, bid 4D (the book says 7+, but that's anti-LoTT).
+    maxSuitLength T.Diamonds 7
+    mapM_ (`maxSuitLength` 3) T.majorSuits
+    makeAlertableCall (T.Bid 3 T.Diamonds) "weak"
 
 
 b1D3N :: Action

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -10,13 +10,13 @@ module Topics.StandardModernPrecision.Bids1D(
   , b1D2N
   , b1D3C
   , b1D3D
---  , b1D3H
---  , b1D3S
+  , b1D3H
+  , b1D3S
   , b1D3N
   , b1D4C
---  , b1D4D
---  , b1D4H
---  , b1D4S
+--  , b1D4D  -- Not sure of definition, so skipped for now
+  , b1D4H
+  , b1D4S
 ) where
 
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
@@ -89,7 +89,7 @@ b1D2D = do
     -- If you've got a major, you must have a 6-card minor.
     alternatives [ minSuitLength T.Diamonds 6
                  , mapM_ (`maxSuitLength` 3) T.majorSuits ]
-    makeAlertableCall (T.Bid 2 T.Diamonds) "invitational or better"
+    makeAlertableCall (T.Bid 2 T.Diamonds) "Invitational or better"
 
 
 b1D2H :: Action
@@ -138,7 +138,22 @@ b1D3D = do
     -- With 8+ diamonds, bid 4D (the book says 7+, but that's anti-LoTT).
     maxSuitLength T.Diamonds 7
     mapM_ (`maxSuitLength` 3) T.majorSuits
-    makeAlertableCall (T.Bid 3 T.Diamonds) "weak"
+    makeAlertableCall (T.Bid 3 T.Diamonds) "Weak"
+
+
+b1D3M :: T.Suit -> Action  -- unexported helper function, used below
+b1D3M suit = do
+    -- The book says this range is 6 to 9 HCP. With 10, maybe consider treating
+    -- your hand as invitational, due to the extra shape?
+    pointRange 6 9
+    suitLength suit 7
+    makeAlertableCall (T.Bid 3 suit) "Weak, 7-card suit"
+
+b1D3H :: Action
+b1D3H = b1D3M T.Hearts
+
+b1D3S :: Action
+b1D3S = b1D3M T.Spades
 
 
 b1D3N :: Action
@@ -156,6 +171,31 @@ b1D4C = do
     minSuitLength T.Clubs 5
     minSuitLength T.Diamonds 5
     makeAlertableCall (T.Bid 4 T.Clubs)
-        "at least 5-5 in the minors, less than invitational strength"
+        "At least 5-5 in the minors, less than invitational strength"
 
 
+-- TODO: The book's definitions for b1D3D contains its definition for b1D4D. Why
+-- would you ever respond 4D, thus preventing opener from bidding a
+-- gambling-like 3N?
+{-
+b1D4D :: Action
+b1D4D = do
+    pointRange 6 9
+    minSuitLength T.Diamonds 8
+    makeAlertableCall (T.Bid 4 T.Diamonds) "Weak, 8-card suit"
+-}
+
+
+b1D4M :: T.Suit -> Action  -- unexported helper function, used below
+b1D4M suit = do
+    pointRange 6 16
+    minSuitLength suit 8
+    makeAlertableCall (T.Bid 4 suit)
+        "Signoff with a very wide range: could be weak and pre-emptive, or\
+       \ game-forcing with no interest in slam"
+
+b1D4H :: Action
+b1D4H = b1D4M T.Hearts
+
+b1D4S :: Action
+b1D4S = b1D4M T.Spades

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -81,7 +81,7 @@ b1D2H = do
     maxSuitLength T.Hearts 5
     pointRange 6 10
     makeAlertableCall (T.Bid 2 T.Hearts)
-        "Reverse Flannery: 5 spades, 4-5 hearts, 6-10 HCP"
+        "5 spades, 4-5 hearts, 6-10 HCP"
 
 
 b1D2S :: Action
@@ -91,6 +91,6 @@ b1D2S = do
     maxSuitLength T.Hearts 5
     pointRange 11 13
     makeAlertableCall (T.Bid 2 T.Spades)
-        "Reverse Flannery: 5 spades, 4-5 hearts, invitational strength"
+        "5 spades, 4-5 hearts, invitational strength"
 
 

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -1,0 +1,43 @@
+module Topics.StandardModernPrecision.Bids1D(
+    b1D
+  , b1D2C
+  , b1D2D
+) where
+
+import Auction(forbid, pointRange, {-suitLength,-} minSuitLength, maxSuitLength,
+               Action, balancedHand, makeCall, makeAlertableCall,
+               {-makePass,-} alternatives)
+--import CommonBids(cannotPreempt)
+import qualified Terminology as T
+
+import Topics.StandardModernPrecision.BasicBids(b1D)
+
+
+b1D2C :: Action
+b1D2C = do
+    pointRange 11 40
+    -- Either you've got 5+ clubs, or you've got 9+ cards in the minors and are
+    -- game forcing (with an invitational hand, start with 2D and rebid 3C).
+    alternatives [ minSuitLength T.Clubs 5
+                 , minSuitLength T.Clubs 4 >> minSuitLength T.Diamonds 5 >>
+                       pointRange 14 40 ]
+    forbid balancedHand
+    -- If you've got a major, you must have a 6-card minor.
+    alternatives [ minSuitLength T.Clubs 6
+                 , mapM_ (`maxSuitLength` 3) T.majorSuits ]
+    makeCall $ T.Bid 2 T.Clubs
+
+
+b1D2D :: Action
+b1D2D = do
+    pointRange 11 40
+    -- Either you've got 5+ diamonds, or you've got 9+ cards in the minors and
+    -- are invitational (with a game forcing hand, start with 2C).
+    alternatives [ minSuitLength T.Diamonds 5
+                 , minSuitLength T.Diamonds 4 >> minSuitLength T.Clubs 5 >>
+                       pointRange 11 13 ]
+    forbid balancedHand
+    -- If you've got a major, you must have a 6-card minor.
+    alternatives [ minSuitLength T.Diamonds 6
+                 , mapM_ (`maxSuitLength` 3) T.majorSuits ]
+    makeAlertableCall (T.Bid 2 T.Diamonds) "invitational or better"

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -8,6 +8,12 @@ module Topics.StandardModernPrecision.Bids1D(
   , b1D2H
   , b1D2S
 --  , b1D2N
+  , b1D3C
+--  , b1D3D
+--  , b1D3H
+--  , b1D3S
+--  , b1D3N
+  , b1D4C
 ) where
 
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
@@ -92,5 +98,24 @@ b1D2S = do
     pointRange 11 13
     makeAlertableCall (T.Bid 2 T.Spades)
         "5 spades, 4-5 hearts, invitational strength"
+
+
+b1D3C :: Action
+b1D3C = do
+    pointRange 6 10
+    alternatives [ suitLength T.Clubs 4 >> minSuitLength T.Diamonds 5
+                 , suitLength T.Diamonds 4 >> minSuitLength T.Clubs 5 ]
+    mapM_ (`maxSuitLength` 3) T.majorSuits
+    makeAlertableCall (T.Bid 3 T.Clubs)
+        "5-4 or 4-5 in the minors, less than invitational strength"
+
+
+b1D4C :: Action
+b1D4C = do
+    pointRange 6 10
+    minSuitLength T.Clubs 5
+    minSuitLength T.Diamonds 5
+    makeAlertableCall (T.Bid 4 T.Clubs)
+        "at least 5-5 in the minors, less than invitational strength"
 
 

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -1,7 +1,7 @@
 module Topics.StandardModernPrecision.Bids1D(
     b1D
   , b1D1H
---  , b1D1S
+  , b1D1S
 --  , b1D1N
   , b1D2C
   , b1D2D
@@ -30,6 +30,18 @@ b1D1H = do
     -- and can reverse later, so bid the hearts first.
     forbid $ compareSuitLength T.Spades Longer T.Hearts
     makeCall $ T.Bid 1 T.Hearts
+
+
+b1D1S :: Action
+b1D1S = do
+    pointRange 6 40
+    minSuitLength T.Spades 4
+    -- If you've got a more specific bid, do that instead
+    mapM_ forbid [b1D2C, b1D2D, b1D2H, b1D2S]
+    -- Your spades should be your longest major. If your hearts are at least as
+    -- long, start with 1H instead.
+    compareSuitLength T.Spades Longer T.Hearts
+    makeCall $ T.Bid 1 T.Spades
 
 
 b1D2C :: Action

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -1,18 +1,35 @@
 module Topics.StandardModernPrecision.Bids1D(
     b1D
+  , b1D1H
+--  , b1D1S
+--  , b1D1N
   , b1D2C
   , b1D2D
   , b1D2H
   , b1D2S
+--  , b1D2N
 ) where
 
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, balancedHand, makeCall, makeAlertableCall,
-               {-makePass,-} alternatives)
---import CommonBids(cannotPreempt)
+               alternatives, SuitLengthComparator(..), compareSuitLength)
 import qualified Terminology as T
 
 import Topics.StandardModernPrecision.BasicBids(b1D)
+
+
+b1D1H :: Action
+b1D1H = do
+    pointRange 6 40
+    minSuitLength T.Hearts 4
+    -- If you've got a more specific bid, do that instead
+    mapM_ forbid [b1D2C, b1D2D, b1D2H, b1D2S]
+    -- With longer spades, bid those first. With equal-length spades, either
+    -- you're 4-4 and you should probably bid the hearts first, or you're 5-5
+    -- and either you're going to bid Reverse Flannery or you're game forcing
+    -- and can reverse later, so bid the hearts first.
+    forbid $ compareSuitLength T.Spades Longer T.Hearts
+    makeCall $ T.Bid 1 T.Hearts
 
 
 b1D2C :: Action

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -2,9 +2,11 @@ module Topics.StandardModernPrecision.Bids1D(
     b1D
   , b1D2C
   , b1D2D
+  , b1D2H
+  , b1D2S
 ) where
 
-import Auction(forbid, pointRange, {-suitLength,-} minSuitLength, maxSuitLength,
+import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, balancedHand, makeCall, makeAlertableCall,
                {-makePass,-} alternatives)
 --import CommonBids(cannotPreempt)
@@ -41,3 +43,25 @@ b1D2D = do
     alternatives [ minSuitLength T.Diamonds 6
                  , mapM_ (`maxSuitLength` 3) T.majorSuits ]
     makeAlertableCall (T.Bid 2 T.Diamonds) "invitational or better"
+
+
+b1D2H :: Action
+b1D2H = do
+    suitLength T.Spades 5
+    minSuitLength T.Hearts 4
+    maxSuitLength T.Hearts 5
+    pointRange 6 10
+    makeAlertableCall (T.Bid 2 T.Hearts)
+        "Reverse Flannery: 5 spades, 4-5 hearts, 6-10 HCP"
+
+
+b1D2S :: Action
+b1D2S = do
+    suitLength T.Spades 5
+    minSuitLength T.Hearts 4
+    maxSuitLength T.Hearts 5
+    pointRange 11 13
+    makeAlertableCall (T.Bid 2 T.Spades)
+        "Reverse Flannery: 5 spades, 4-5 hearts, invitational strength"
+
+

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -2,17 +2,17 @@ module Topics.StandardModernPrecision.Bids1D(
     b1D
   , b1D1H
   , b1D1S
---  , b1D1N
+  , b1D1N
   , b1D2C
   , b1D2D
   , b1D2H
   , b1D2S
---  , b1D2N
+  , b1D2N
   , b1D3C
 --  , b1D3D
 --  , b1D3H
 --  , b1D3S
---  , b1D3N
+  , b1D3N
   , b1D4C
 ) where
 
@@ -48,6 +48,15 @@ b1D1S = do
     -- long, start with 1H instead.
     compareSuitLength T.Spades Longer T.Hearts
     makeCall $ T.Bid 1 T.Spades
+
+
+b1D1N :: Action
+b1D1N = do
+    pointRange 6 10
+    balancedHand
+    maxSuitLength T.Hearts 3
+    maxSuitLength T.Spades 3
+    makeCall $ T.Bid 1 T.Notrump
 
 
 b1D2C :: Action
@@ -100,6 +109,15 @@ b1D2S = do
         "5 spades, 4-5 hearts, invitational strength"
 
 
+b1D2N :: Action
+b1D2N = do
+    pointRange 11 12
+    balancedHand
+    maxSuitLength T.Hearts 3
+    maxSuitLength T.Spades 3
+    makeCall $ T.Bid 2 T.Notrump
+
+
 b1D3C :: Action
 b1D3C = do
     pointRange 6 10
@@ -108,6 +126,15 @@ b1D3C = do
     mapM_ (`maxSuitLength` 3) T.majorSuits
     makeAlertableCall (T.Bid 3 T.Clubs)
         "5-4 or 4-5 in the minors, less than invitational strength"
+
+
+b1D3N :: Action
+b1D3N = do
+    pointRange 13 16
+    balancedHand
+    maxSuitLength T.Hearts 3
+    maxSuitLength T.Spades 3
+    makeCall $ T.Bid 3 T.Notrump
 
 
 b1D4C :: Action

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -1,9 +1,9 @@
 module Topics.StandardModernPrecision.Mafia(topic) where
 
-import Output(output)
+import Output(output, Punct(..))
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, forbid, minSuitLength, suitLength, balancedHand,
-               SuitLengthComparator(..), compareSuitLength, extractLastCall)
+               SuitLengthComparator(..), compareSuitLength, displayLastCall)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(smpWrapS)
@@ -144,9 +144,9 @@ jumpBid = let
             "With an unbalanced hand that is strong enough to\
            \ force to game, jump in your suit. Responder can treat this like\
            \ the 2/1 sequence " ++
-            output fmt (T.Bid 2 T.Clubs) ++ "--" ++
-            output fmt (T.Bid 2 T.Diamonds) ++ "--" ++
-            output fmt (extractLastCall bid) ++ "."
+            output fmt (T.Bid 2 T.Clubs) ++ output fmt NDash ++
+            output fmt (T.Bid 2 T.Diamonds) ++ output fmt NDash ++
+            displayLastCall fmt bid ++ "."
       in
         situation "J1" action bid explanation
   in

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -1,4 +1,4 @@
-module Topics.StandardModernPrecision.ResponsesToStrongClub(topic) where
+module Topics.StandardModernPrecision.OneClubResponses(topic) where
 
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
@@ -194,7 +194,7 @@ passTwoSpades = let
 
 
 topic :: Topic
-topic = Topic "SMP immediate responses to 1C" "SMP1C" situations
+topic = Topic "SMP immediate responses to 1C openings" "SMP1C" situations
   where
     situations = wrap [ oneDiamond
                       , oneHeart

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -72,10 +72,51 @@ reverseFlannery = let
     smpWrapN $ return sit <~ [(B.b1D2H, False), (B.b1D2S, True)]
 
 
+weakMinors54 :: Situations
+weakMinors54 = let
+    sit = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid B.b1D3C
+        explanation fmt =
+            "With 5-4 in the minors, no 4-card major, and less than\
+           \ invitational strength, bid a pre-emptive-like " ++
+             output fmt (T.Bid 3 T.Clubs) ++ ". Partner can pass or correct, or\
+           \ even continue the pre-empt if relevant. We might get unlucky and\
+           \ end up in a 7-card fit, but most of the time we'll have a decent\
+           \ fit in opener's favorite minor."
+      in
+        situation "54min" action B.b1D3C explanation
+  in
+    smpWrapN $ return sit
+
+
+weakMinors55 :: Situations
+weakMinors55 = let
+    sit = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid B.b1D4C
+        explanation fmt =
+            "With at least 5-5 in the minors and less than invitational\
+           \ strength,\
+           \ bid a pre-emptive-like " ++ output fmt (T.Bid 4 T.Clubs) ++ ".\
+           \ Partner can pass or correct, or even continue the pre-empt if\
+           \ relevant. We're guaranteed at least an 8-card fit in opener's\
+           \ favorite minor."
+      in
+        situation "55min" action B.b1D4C explanation
+  in
+    smpWrapN $ return sit
+
+
 topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
     situations = wrap [ twoMinor6M
                       , oneMajor
                       , reverseFlannery
+                      , wrap [weakMinors54, weakMinors55]
                       ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,0 +1,40 @@
+module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
+
+--import Output(output)
+import Topic(Topic(..), wrap, Situations)
+import Auction(withholdBid, {-forbid, makePass,-} maxSuitLength, minSuitLength, {-suitLength,-}
+               {-Action, balancedHand,-} pointRange{-, SuitLengthComparator(..), compareSuitLength-})
+import Situation(situation, (<~))
+--import CommonBids(cannotPreempt)
+import qualified Terminology as T
+import Topics.StandardModernPrecision.BasicBids(oppsPass, b1D, smpWrapN)
+import qualified Topics.StandardModernPrecision.Bids1D as B
+
+
+twoMinor6M :: Situations
+twoMinor6M = let
+    sit (minor, bid) major = let
+        action = do
+            b1D
+            oppsPass
+            minSuitLength minor 6
+            minSuitLength major 4
+            maxSuitLength major 5
+            pointRange 14 40
+            withholdBid bid
+        explanation _ =
+            "With game-forcing strength, a 4- or 5-card major, but a 6+ card\
+           \ minor, start by bidding 2 of the minor. There will be time to\
+           \ show the major afterward."
+      in
+        situation "6m" action bid explanation
+  in
+    smpWrapN $ return sit <~ [(T.Clubs, B.b1D2C), (T.Diamonds, B.b1D2D)]
+                          <~ [T.Hearts, T.Spades]
+
+
+topic :: Topic
+topic = Topic "responses to SMP 1D openings" "smp1d" situations
+  where
+    situations = wrap [ twoMinor6M
+                      ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -2,8 +2,8 @@ module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
 import Output(output, Punct(..))
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid, {-forbid,-} maxSuitLength, minSuitLength, {-suitLength,-}
-               {-Action,-} pointRange, displayLastCall, alternatives)
+import Auction(withholdBid, maxSuitLength, minSuitLength, pointRange,
+               displayLastCall, alternatives)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(oppsPass, b1D, smpWrapN)

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -3,7 +3,7 @@ module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, {-forbid, makePass,-} maxSuitLength, minSuitLength, {-suitLength,-}
-               {-Action, balancedHand,-} pointRange{-, SuitLengthComparator(..), compareSuitLength-})
+               {-Action, balancedHand,-} pointRange{-, SuitLengthComparator(..), compareSuitLength-}, displayLastCall)
 import Situation(situation, (<~))
 --import CommonBids(cannotPreempt)
 import qualified Terminology as T
@@ -49,9 +49,33 @@ twoMinor6M = let
                           <~ [T.Hearts, T.Spades]
 
 
+reverseFlannery :: Situations
+reverseFlannery = let
+    sit (bid, isInvite) = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid bid
+        explanation fmt =
+            "With 5 spades, 4 or 5 hearts, and " ++
+            if isInvite then "" else "less than " ++
+            "invitational strength, bid a Reverse Flannery " ++
+            displayLastCall fmt bid ++ ". Partner can then place the final\
+          \ contract, bid " ++ output fmt (T.Bid 3 T.Clubs) ++ " (pass or\
+          \ correct) with both minors, or bid " ++
+            output fmt (T.Bid 2 T.Notrump) ++ " to ask for\
+          \ more information. Note that if you were game forcing, you would\
+          \ have started at the 1 level instead."
+      in
+        situation "RevFl" action bid explanation
+  in
+    smpWrapN $ return sit <~ [(B.b1D2H, False), (B.b1D2S, True)]
+
+
 topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
     situations = wrap [ twoMinor6M
                       , oneMajor
+                      , reverseFlannery
                       ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -116,7 +116,6 @@ notrump1 :: Situations
 notrump1 = let
     sit = let
         action = do
-            minSuitLength T.Hearts 5
             b1D
             oppsPass
             withholdBid B.b1D1N
@@ -126,7 +125,7 @@ notrump1 = let
            \ will likely pass, but could bid 2 of a major with 6-5 and a\
            \ maximum, which you can pass or correct."
       in
-        situation "1nt" action B.b1D1N explanation
+        situation "1N" action B.b1D1N explanation
   in
     smpWrapN $ return sit
 
@@ -135,7 +134,6 @@ notrump2 :: Situations
 notrump2 = let
     sit = let
         action = do
-            minSuitLength T.Hearts 5
             b1D
             oppsPass
             withholdBid B.b1D2N
@@ -154,7 +152,7 @@ notrump2 = let
            \ or 4 of a major with 6-5 and a maximum, which you can pass or\
            \ correct."
       in
-        situation "2nt" action B.b1D2N explanation
+        situation "2N" action B.b1D2N explanation
   in
     smpWrapN $ return sit
 
@@ -163,7 +161,6 @@ notrump3 :: Situations
 notrump3 = let
     sit = let
         action = do
-            minSuitLength T.Hearts 5
             b1D
             oppsPass
             withholdBid B.b1D3N
@@ -176,7 +173,7 @@ notrump3 = let
              output fmt (T.Bid 4 T.Notrump) ++ " or " ++
              output fmt (T.Bid 5 T.Diamonds) ++ "."
       in
-        situation "3nt" action B.b1D3N explanation
+        situation "3N" action B.b1D3N explanation
   in
     smpWrapN $ return sit
 

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -178,6 +178,24 @@ notrump3 = let
     smpWrapN $ return sit
 
 
+invertedMinors :: Situations
+invertedMinors = let
+    sit = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid B.b1D3D
+        explanation fmt =
+            "With less than invitational strength, no 4-card major, but a long\
+           \ diamond suit, jump to " ++ displayLastCall fmt B.b1D3D ++ ", like\
+           \ an inverted minor. Note that you need 6+ cards in the suit to do\
+           \ this, since opener might only have a doubleton."
+      in
+        situation "3d" action B.b1D3D explanation
+  in
+    smpWrapN $ return sit
+
+
 topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
@@ -186,4 +204,5 @@ topic = Topic "responses to SMP 1D openings" "smp1d" situations
                       , reverseFlannery
                       , wrap [weakMinors54, weakMinors55]
                       , wrap [notrump1, notrump2, notrump3]
+                      , invertedMinors
                       ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
---import Output(output)
+import Output(output)
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, {-forbid, makePass,-} maxSuitLength, minSuitLength, {-suitLength,-}
                {-Action, balancedHand,-} pointRange{-, SuitLengthComparator(..), compareSuitLength-})
@@ -9,6 +9,22 @@ import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(oppsPass, b1D, smpWrapN)
 import qualified Topics.StandardModernPrecision.Bids1D as B
+
+
+oneMajor :: Situations
+oneMajor = let
+    sit (suit, bid) = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid bid
+        explanation fmt =
+            "Let's start with a natural " ++ output fmt (T.Bid 1 suit) ++ "\
+           \ bid, and see where things go from there."
+      in
+        situation "1M" action bid explanation
+  in
+    smpWrapN $ return sit <~ [(T.Hearts, B.b1D1H), (T.Spades, B.b1D1S)]
 
 
 twoMinor6M :: Situations
@@ -37,4 +53,5 @@ topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
     situations = wrap [ twoMinor6M
+                      , oneMajor
                       ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
-import Output(output)
+import Output(output, Punct(..))
 import Topic(Topic(..), wrap, Situations)
 import Auction(withholdBid, {-forbid, makePass,-} maxSuitLength, minSuitLength, {-suitLength,-}
                {-Action, balancedHand,-} pointRange{-, SuitLengthComparator(..), compareSuitLength-}, displayLastCall)
@@ -112,6 +112,75 @@ weakMinors55 = let
     smpWrapN $ return sit
 
 
+notrump1 :: Situations
+notrump1 = let
+    sit = let
+        action = do
+            minSuitLength T.Hearts 5
+            b1D
+            oppsPass
+            withholdBid B.b1D1N
+        explanation fmt =
+            "With a balanced hand, no 4-card major, and less than invitational\
+           \ strength, bid " ++ output fmt (T.Bid 1 T.Notrump) ++ ". Partner\
+           \ will likely pass, but could bid 2 of a major with 6-5 and a\
+           \ maximum, which you can pass or correct."
+      in
+        situation "1nt" action B.b1D1N explanation
+  in
+    smpWrapN $ return sit
+
+
+notrump2 :: Situations
+notrump2 = let
+    sit = let
+        action = do
+            minSuitLength T.Hearts 5
+            b1D
+            oppsPass
+            withholdBid B.b1D2N
+        explanation fmt =
+            "With a balanced hand, no 4-card major, and 11" ++
+             output fmt NDash ++ "12 HCP, bid " ++
+             output fmt (T.Bid 2 T.Notrump) ++ ". Note that 13 HCP hands should\
+           \ bid game even though they're usually considered invitational!\
+           \ Partner can pass, bid " ++ output fmt (T.Bid 3 T.Clubs) ++ "\
+           \ (pass or correct) with both minors and a minimum (with a maximum,\
+           \ prefer playing in " ++ output fmt (T.Bid 2 T.Notrump) ++ "), " ++
+             output fmt (T.Bid 3 T.Diamonds) ++ " with a long suit and minimum\
+           \ strength, 3 of a major with 4 cards in that major and shortness in\
+           \ the other one (angling for " ++ output fmt (T.Bid 3 T.Notrump) ++
+            " or 4 of a minor if you don't have a stopper in the other major),\
+           \ or 4 of a major with 6-5 and a maximum, which you can pass or\
+           \ correct."
+      in
+        situation "2nt" action B.b1D2N explanation
+  in
+    smpWrapN $ return sit
+
+
+notrump3 :: Situations
+notrump3 = let
+    sit = let
+        action = do
+            minSuitLength T.Hearts 5
+            b1D
+            oppsPass
+            withholdBid B.b1D3N
+        explanation fmt =
+            "With a balanced hand, no 4-card major, and 13" ++
+            output fmt NDash ++ "16 HCP, bid " ++
+            output fmt (T.Bid 3 T.Notrump) ++ ". Partner\
+           \ will likely pass, but could bid game in a major with 6-5 shape,\
+           \ which you can pass or correct to " ++
+             output fmt (T.Bid 4 T.Notrump) ++ " or " ++
+             output fmt (T.Bid 5 T.Diamonds) ++ "."
+      in
+        situation "3nt" action B.b1D3N explanation
+  in
+    smpWrapN $ return sit
+
+
 topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
@@ -119,4 +188,5 @@ topic = Topic "responses to SMP 1D openings" "smp1d" situations
                       , oneMajor
                       , reverseFlannery
                       , wrap [weakMinors54, weakMinors55]
+                      , wrap [notrump1, notrump2, notrump3]
                       ]

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -259,7 +259,7 @@ majorGame = let
 
 
 topic :: Topic
-topic = Topic "responses to SMP 1D openings" "smp1d" situations
+topic = Topic "SMP immediate responses to 1D openings" "smp1d" situations
   where
     situations = wrap [ twoMinor6M
                       , oneMajor

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -13,18 +13,18 @@ import qualified Topics.StandardModernPrecision.Bids1D as B
 
 oneMajor :: Situations
 oneMajor = let
-    sit (suit, bid) = let
+    sit bid = let
         action = do
             b1D
             oppsPass
             withholdBid bid
         explanation fmt =
-            "Let's start with a natural " ++ output fmt (T.Bid 1 suit) ++ "\
+            "Let's start with a natural " ++ displayLastCall fmt bid ++ "\
            \ bid, and see where things go from there."
       in
         situation "1M" action bid explanation
   in
-    smpWrapN $ return sit <~ [(T.Hearts, B.b1D1H), (T.Spades, B.b1D1S)]
+    smpWrapN $ return sit <~ [B.b1D1H, B.b1D1S]
 
 
 twoMinor6M :: Situations

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -58,7 +58,7 @@ reverseFlannery = let
             withholdBid bid
         explanation fmt =
             "With 5 spades, 4 or 5 hearts, and " ++
-            if isInvite then "" else "less than " ++
+            (if isInvite then "" else "less than ") ++
             "invitational strength, bid a Reverse Flannery " ++
             displayLastCall fmt bid ++ ". Partner can then place the final\
           \ contract, bid " ++ output fmt (T.Bid 3 T.Clubs) ++ " (pass or\
@@ -196,6 +196,68 @@ invertedMinors = let
     smpWrapN $ return sit
 
 
+preempt3M :: Situations
+preempt3M = let
+    sit bid = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid bid
+        explanation _ =
+            "With a weak hand and a 7-card major, jump to 3 of that suit.\
+           \ Opener should pretend that you opened with a pre-empt: they will\
+           \ likely pass, even if we don't have a great fit, but can continue\
+           \ the pre-empt with a fit if the opponents try to enter the auction."
+      in
+        situation "3M" action bid explanation
+  in
+    smpWrapN $ return sit <~ [B.b1D3H, B.b1D3S]
+
+
+-- TODO: uncomment this and get it right when you're more confident of the
+-- definition of a 4D response.
+{-
+preempt4D :: Situations
+preempt4D = let
+    sit = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid B.b1D4D
+        explanation _ =
+            "With a weak hand and 8-card support for partner's diamonds, jump\
+           \ to 4 of that suit. Opener has at least a doubleton, so on the LoTT\
+           \ you're probably safe to the 4 level."
+        -- TODO: not sure that's right. What if you've got a running diamond
+        -- suit between the two of you and you belong in a gambling-like 3N?
+      in
+        situation "4D" action bid explanation
+  in
+    smpWrapN $ return sit
+-}
+
+
+majorGame :: Situations
+majorGame = let
+    sit bid = let
+        action = do
+            b1D
+            oppsPass
+            withholdBid bid
+        explanation _ =
+            "With an 8-card major, jump to game. This bid has a very wide\
+           \ point range, which makes it difficult for the opponents because\
+           \ maybe you're pre-empting and maybe you're game forcing with no\
+           \ interest in slam. Regardless, game in your major is the right\
+           \ place to stop, so bid it immediately without giving the opponents\
+           \ a chance to jump into the auction."
+      in
+        situation "4M" action bid explanation
+  in
+    smpWrapN $ return sit <~ [B.b1D4H, B.b1D4S]
+
+
+
 topic :: Topic
 topic = Topic "responses to SMP 1D openings" "smp1d" situations
   where
@@ -204,5 +266,6 @@ topic = Topic "responses to SMP 1D openings" "smp1d" situations
                       , reverseFlannery
                       , wrap [weakMinors54, weakMinors55]
                       , wrap [notrump1, notrump2, notrump3]
-                      , invertedMinors
+                      -- TODO: Add preempt4D to this line when it's implemented.
+                      , wrap [invertedMinors, preempt3M, majorGame]
                       ]


### PR DESCRIPTION
Also included: `displayLastCall` formats an `Action` into a string as just the last call without any alerts, for use in the explanation of why it's the right one.

I need to firm up the constraints around what the opponents might have, when they pass after partner opens. Currently, for example, they pass with 14 HCP and a 5-card suit they could have overcalled at the 1 level. but this PR is already far too long, so that can come later. and getting it right could be pretty tricky, given that the constraints on what they might be able to overcall depends on what the most recent bid was.

An open question for me: the book defines the auction 1D-3D as showing "6 or more diamonds, with about 5 to 10 HCP," and defines the auction 1D-4D as showing "7 cards in the suit and 6-9 HCP." When would you ever bid the latter, given that in those cases you could also have bid the former? I'm unsure, so I left out those auctions and have a TODO for them. :shrug: 