### PR TITLE
bugfixes and nits

### DIFF
--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -38,7 +38,7 @@ instance Showable SituationInstance where
 instantiate :: String -> Situation ->
         State StdGen (IO (Maybe SituationInstance))
 instantiate reference (Situation _ b dl c s v dn) = do
-    n <- use (first (fromInteger . toInteger) . genWord64)
+    n <- use (first fromIntegral . genWord64)
     let instantiate' :: IO (Maybe SituationInstance)
         instantiate' = do
             maybeDeal <- eval dn v dl n

--- a/src/Topics/StandardModernPrecision/BasicBids.hs
+++ b/src/Topics/StandardModernPrecision/BasicBids.hs
@@ -19,9 +19,9 @@ import Control.Monad.Trans.State.Strict(State)
 import System.Random(StdGen)
 
 import Topic(wrap, Situations)
-import Auction(forbid, pointRange, suitLength, minSuitLength,
+import Auction(forbid, pointRange, suitLength, minSuitLength, hasTopN,
                Action, balancedHand, constrain, makeCall, makeAlertableCall,
-               makePass)
+               makePass, alternatives)
 import Situation(Situation, (<~))
 import CommonBids(cannotPreempt)
 import qualified Terminology as T
@@ -58,18 +58,17 @@ b2N = do
     makeAlertableCall (T.Bid 2 T.Notrump) "19-20 HCP"
 
 
--- TODO: switch to gambling 3N, and make this 1C-and-rebid-3N
 b3N :: Action
 b3N = do
-    pointRange 24 40  -- Technically only 24-27, but close enough
-    balancedHand
-    makeCall $ T.Bid 3 T.Notrump
+    alternatives . map (\suit -> minSuitLength suit 7 >> hasTopN suit 5 4) $
+        T.minorSuits
+    makeAlertableCall (T.Bid 3 T.Notrump) "Gambling: long running minor"
 
 
 b1C :: Action
 b1C = do
     pointRange 16 40
-    mapM_ forbid [b1N, b2N, b3N]
+    mapM_ forbid [b1N, b2N]
     makeAlertableCall (T.Bid 1 T.Clubs) "16+ HCP, any shape"
 
 

--- a/src/Topics/StandardModernPrecision/Bids1C.hs
+++ b/src/Topics/StandardModernPrecision/Bids1C.hs
@@ -400,6 +400,7 @@ b1C1D1S2H = do
     forbid b1C1D1S3S
     -- Prefer showing 3-card spade support over your own 5-card heart suit.
     forbid b1C1D1S2D
+    forbid b1C1D1S2N
     pointRange 6 7
     -- We need at least 5 hearts, since opener has at most 3 (unless they're
     -- two-suited with both majors and longer spades, but that's rare and we'll

--- a/src/Topics/StandardModernPrecision/Bids1D.hs
+++ b/src/Topics/StandardModernPrecision/Bids1D.hs
@@ -46,7 +46,7 @@ b1D1S = do
     pointRange 6 40
     minSuitLength T.Spades 4
     -- If you've got a more specific bid, do that instead
-    mapM_ forbid [b1D2C, b1D2D, b1D2H, b1D2S]
+    mapM_ forbid [b1D2C, b1D2D, b1D2H, b1D2S, b1D3S]
     -- Your spades should be your longest major. If your hearts are at least as
     -- long, start with 1H instead.
     compareSuitLength T.Spades Longer T.Hearts


### PR DESCRIPTION
- Use `fromIntegral` instead of `fromInteger . toInteger`
- After an SMP 1C-1D-1S, prefer to support opener's major with 4-card support even if you've got 5 hearts.
- After partner opens an SMP 1D, prefer to bid 3S instead of 1S if you've got a weak hand with a 7-card suit
- Use Gambling 3N in SMP (no situations implemented yet). To show a balanced 24+ HCP, open 1C and rebid 3N (not implemented; will get around to it eventually)