### PR TITLE
advanced SMP: 1C-1H denies 4 spades and swapped meanings of 1C-1N and 1C-2H

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,6 +17,7 @@ import ProblemSet(outputLatex)
 main :: IO ()
 main = let
     topics = [ --SmpOpenings.topic
+             --, Smp1CResponses.topic
               Smp1CResponses.topicExtras
              --, Mafia.topic
              --, MafiaResponses.topic

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,12 +16,12 @@ import ProblemSet(outputLatex)
 
 main :: IO ()
 main = let
-    topics = [ SmpOpenings.topic
-             , Smp1CResponses.topic
-             , Mafia.topic
-             , MafiaResponses.topic
-             , Smp1DResponses.topic
-             , Smp2DOpen.topic
+    topics = [ --SmpOpenings.topic
+              Smp1CResponses.topicExtras
+             --, Mafia.topic
+             --, MafiaResponses.topic
+             --, Smp1DResponses.topic
+             --, Smp2DOpen.topic
              ]
   in do
     outputLatex 100 topics "test" (mkStdGen 0)

--- a/src/Topics/StandardModernPrecision/Bids1C.hs
+++ b/src/Topics/StandardModernPrecision/Bids1C.hs
@@ -3,7 +3,9 @@ module Topics.StandardModernPrecision.Bids1C(
   -- Responses to 1C
   , b1C1D
   , b1C1H
+  , b1C1Hnos
   , b1C1S
+  , b1C1Sgf
   , b1C1N
   , b1C2C
   , b1C2D
@@ -71,9 +73,23 @@ b1C1H = do
     makeAlertableCall (T.Bid 1 T.Hearts) "8-11 HCP, any shape"
 
 
+b1C1Hnos :: Action
+b1C1Hnos = do
+    _gameForcing
+    maxSuitLength T.Spades 4
+    makeAlertableCall (T.Bid 1 T.Hearts) "8-11 HCP, any shape without 5+ spades"
+
+
 b1C1S :: Action
 b1C1S = do
     _slamInterest
+    minSuitLength T.Spades 5
+    makeCall $ T.Bid 1 T.Spades
+
+
+b1C1Sgf :: Action
+b1C1Sgf = do
+    pointRange 8 40
     minSuitLength T.Spades 5
     makeCall $ T.Bid 1 T.Spades
 

--- a/src/Topics/StandardModernPrecision/Bids1C.hs
+++ b/src/Topics/StandardModernPrecision/Bids1C.hs
@@ -7,9 +7,11 @@ module Topics.StandardModernPrecision.Bids1C(
   , b1C1S
   , b1C1Sgf
   , b1C1N
+  , b1C1Nalt
   , b1C2C
   , b1C2D
   , b1C2H
+  , b1C2Halt
   , b1C2S
   , bP1C1H
   , bP1C1S
@@ -115,12 +117,27 @@ b1C2H = do
     makeCall $ T.Bid 2 T.Hearts
 
 
+b1C2Halt :: Action  -- Alternative choice: swap the meanings of b1C1N and b1C2H
+b1C2Halt = do
+    _slamInterest
+    balancedHand
+    mapM_ (`maxSuitLength` 4) T.allSuits
+    makeAlertableCall (T.Bid 2 T.Hearts) "12+ HCP, any 4333 or 4432 shape"
+
+
 b1C1N :: Action
 b1C1N = do
     _slamInterest
     balancedHand
     mapM_ (`maxSuitLength` 4) T.allSuits
     makeCall $ T.Bid 1 T.Notrump
+
+
+b1C1Nalt :: Action  -- Alternative choice: swap the meanings of b1C1N and b1C2H
+b1C1Nalt = do
+    _slamInterest
+    minSuitLength T.Hearts 5
+    makeAlertableCall (T.Bid 1 T.Notrump) "12+ HCP, 5+ hearts"
 
 
 b1C2S :: Action

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -158,21 +158,17 @@ oneSpadeGF = let
       \ with " ++ output fmt (T.Bid 1 T.Spades) ++ " to show partner we'e at\
       \ least game forcing. When you find a fit, start control bidding to show\
       \ partner you're interested in slam, too."
-    sit (explanation, givenPoints) = let
+    sit (explanation, minHcp, maxHcp) = let
         action = do
             firstSeatOpener
             b1C
             oppsPass
-            -- The compiler is concerned that we're discarding a result value on
-            -- this next line, but suggests that if it's on purpose, we can use
-            -- `_` to suppress it. The result we're discarding is the () unit.
-            _ <- givenPoints
+            pointRange minHcp maxHcp
             withholdBid B.b1C1Sgf
       in
-        situation "Slam" action B.b1C1Sgf explanation
+        situation "1Sgf" action B.b1C1Sgf explanation
   in
-    smpWrapN $ return sit <~ [(explanationMin, pointRange 8 11),
-                              (explanationMax, pointRange 12 40)]
+    smpWrapN $ return sit <~ [(explanationMin, 8, 11), (explanationMax, 12, 40)]
 
 twoSpades :: Situations
 twoSpades = let

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -74,6 +74,25 @@ oneNotrump = let
     smpWrapN . return $ situation "1N" action B.b1C1N explanation
 
 
+oneNotrumpAlt :: Situations
+oneNotrumpAlt = let
+    action = do
+        firstSeatOpener
+        b1C
+        oppsPass
+        withholdBid B.b1C1Nalt
+    explanation fmt =
+        "You've got at least mild slam interest with 12+ HCP, and a 5-card\
+      \ heart suit. Bid " ++ output fmt (T.Bid 1 T.Notrump) ++ " to show this.\
+      \ Partner's bids are natural: " ++ output fmt (T.Bid 2 T.Hearts) ++ " is\
+      \ a heart raise, other suits are 5 cards long, and " ++
+        output fmt (T.Bid 2 T.Notrump) ++ " shows a notrump response.\
+      \ Compared to the naive approach, this never wastes extra bidding room\
+      \ and often saves some for control bids after we've found a fit."
+  in
+    smpWrapN . return $ situation "1Nalt" action B.b1C1Nalt explanation
+
+
 slamSingleSuit :: Situations
 slamSingleSuitModified :: Situations
 (slamSingleSuit, slamSingleSuitModified) = let
@@ -102,7 +121,28 @@ slamSingleSuitModified :: Situations
         situation "Slam" action bid explanation
   in
     ( smpWrapN $ return sit <~ T.allSuits
-    , smpWrapN $ return sit <~ [T.Clubs, T.Diamonds, T.Hearts])
+    , smpWrapN $ return sit <~ [T.Clubs, T.Diamonds])
+
+
+twoHeartsBalanced :: Situations
+twoHeartsBalanced = let
+    action = do
+        firstSeatOpener
+        b1C
+        oppsPass
+        withholdBid B.b1C2Halt
+    explanation fmt =
+        "You've got at least mild slam interest with 12+ HCP, but a balanced\
+      \ hand with no 5-card suit. Bid " ++ output fmt (T.Bid 2 T.Hearts) ++ "\
+      \ to show this. Partner can try " ++ output fmt (T.Bid 2 T.Notrump) ++ "\
+      \ to show hearts, " ++ output fmt (T.Bid 3 T.Clubs) ++ " as Stayman\
+      \ (regular-type! Puppet is not needed because you've already denied a\
+      \ 5-card major), or otherwise bid naturally. If partner has clubs,\
+      \ they're likely to prefer notrump, but could also try a jump to " ++
+        output fmt (T.Bid 3 T.Spades) ++ " to show that (which should be\
+      \ surprising enough for you to recognize/remember)."
+  in
+    smpWrapN . return $ situation "2HAlt" action B.b1C2Halt explanation
 
 
 oneSpadeGF :: Situations
@@ -247,7 +287,7 @@ topic = Topic "SMP immediate responses to 1C openings" "SMP1C" situations
   where
     situations = wrap [ oneDiamond
                       , oneHeart  -- Differs from topicExtras, below
-                      , oneNotrump
+                      , oneNotrump  -- Differs from topicExtras, below
                       , slamSingleSuit  -- Differs from topicExtras, below
                       , twoSpades
                       , passGameSingleSuit
@@ -262,8 +302,9 @@ topicExtras = Topic "SMP modified immediate responses to 1C openings"
     situations = wrap [ oneDiamond
                       , oneHeartNoSpades  -- Differs from topic, above
                       , oneSpadeGF  -- Differs from topic, above
-                      , oneNotrump
+                      , oneNotrumpAlt  -- Differs from topic, above
                       , slamSingleSuitModified  -- Differs from topic, above
+                      , twoHeartsBalanced  -- Differs from topic, above
                       , twoSpades
                       , passGameSingleSuit
                       , passOneNotrump


### PR DESCRIPTION
Still left to do: the waiting bids after 1C-1H (2S is a waiting bid unless you could have bid 2D, in which case that's waiting and 2S shows diamonds). That should probably be separate files, which means it should probably be a separate PR.

Not sure I like these names: they're intended to have the bids be upper case and the extra parts be lower case, but the `alt`ernative version of `2H` looks like some kind of `Halt` action. I'll either think of better names, or merge this and think of better names later.