### PR TITLE
Withhold the answer Action from the Auction

### DIFF
--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -8,7 +8,7 @@ module Situation (
 import Control.Monad.Trans.State.Strict(State)
 import System.Random(StdGen)
 
-import Auction(Action, finish, extractLastCall)
+import Auction(Action, finish, extractLastCall, withholdBid)
 import DealerProg(DealerProg)
 import Output(Commentary)
 import Random(pickItem)
@@ -27,7 +27,7 @@ situation :: String -> Action -> Action -> Commentary -> Vulnerability ->
     Direction -> Situation
 situation r a c s v d = Situation r bidding deal answer s v d
   where
-    (bidding, deal) = finish d a
+    (bidding, deal) = finish d (a >> withholdBid c)
     answer = extractLastCall c
 
 

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -2,8 +2,8 @@ module Topics.StandardModernPrecision.Mafia(topic) where
 
 import Output(output, Punct(..))
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid, forbid, minSuitLength, suitLength, balancedHand,
-               equalLength, longerThan, displayLastCall)
+import Auction(forbid, minSuitLength, suitLength, balancedHand, equalLength,
+               longerThan, displayLastCall)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(smpWrapS)
@@ -15,7 +15,6 @@ notrump = let
     sit bid = let
         action = do
             B.startOfMafia
-            withholdBid bid
         explanation _ =
             "With a balanced hand, rebid notrump to show your point range.\
            \ Even if you have a 5-card major, it's better to know that\
@@ -32,7 +31,6 @@ oneMajor = let
         action = do
             B.startOfMafia
             forbid balancedHand
-            withholdBid bid
         explanation _ =
             "With an unbalanced hand that isn't game forcing, bid a 4-card\
            \ major if you have one."
@@ -50,7 +48,6 @@ oneMajorMinor = let
             forbid balancedHand
             minSuitLength minorSuit 5
             suitLength majorSuit 4
-            withholdBid bid
         explanation _ =
             "With an unbalanced hand that isn't game forcing, bid a 4-card\
            \ major if you have one. This holds even if you've got a longer\
@@ -69,7 +66,6 @@ twoMinorSingle = let
             B.startOfMafia
             forbid balancedHand
             minSuitLength minorSuit 6
-            withholdBid bid
         explanation _ =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, bid your long minor."
@@ -86,7 +82,8 @@ twoMinorMinors = let
             B.startOfMafia
             forbid balancedHand
             suitLength minorSuit 5
-            withholdBid bid  -- Ensures the bid minor is longer than the other
+            -- The answer Action also ensures that the minor we bid is longer
+            -- than the minor we don't bid.
         explanation _ =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, rebid your long minor. Sometimes this minor is\
@@ -104,7 +101,6 @@ equalMinors = let
             B.startOfMafia
             forbid balancedHand
             T.Clubs `equalLength` T.Diamonds
-            withholdBid B.b1C1D2D
         explanation _ =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, rebid your long minor. When the minors are the\
@@ -139,7 +135,6 @@ jumpBid = let
     sit bid = let
         action = do
             B.startOfMafia
-            withholdBid bid
         explanation fmt =
             "With an unbalanced hand that is strong enough to\
            \ force to game, jump in your suit. Responder can treat this like\

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -2,7 +2,7 @@ module Topics.StandardModernPrecision.MafiaResponses(topic) where
 
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid, Action, suitLength, maxSuitLength)
+import Auction(Action, suitLength, maxSuitLength)
 import Situation(Situation, situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(oppsPass, smpWrapN)
@@ -19,7 +19,6 @@ minSupport = let
             B.startOfMafia
             openerBid
             oppsPass
-            withholdBid responderBid
         explanation _ =
             "With 4-card support and a minimum hand, raise partner's major.\
            \ You are neither strong enough nor shapely enough to invite to\
@@ -41,7 +40,6 @@ maxSupportSemibalanced = let
             B.startOfMafia
             openerBid
             oppsPass
-            withholdBid responderBid
         explanation fmt =
             "With 4-card support and a maximum hand but no singleton, invite\
            \ with a double raise. You've already shown that game might not be\
@@ -64,7 +62,6 @@ maxSupportUnbalanced = let
             B.startOfMafia
             openerBid
             oppsPass
-            withholdBid responderBid
         explanation fmt =
             "With 4-card support, a maximum hand, and a singleton or void,\
            \ make a mini-splinter bid with " ++
@@ -88,7 +85,6 @@ brakesHearts = let
             B.startOfMafia
             B.b1C1D1H
             oppsPass
-            withholdBid B.b1C1D1H1N
         explanation fmt =
             "With neither major and a non-maximum hand, bid " ++
              output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
@@ -111,7 +107,6 @@ brakesSpades = let
             B.b1C1D1S
             oppsPass
             maxSuitLength T.Hearts 4
-            withholdBid B.b1C1D1S1N
         explanation fmt =
             "With a minimum hand and no support for partner's spades, bid " ++
              output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
@@ -134,7 +129,6 @@ brakesSpadesHearts = let
             B.b1C1D1S
             oppsPass
             suitLength T.Hearts 5
-            withholdBid B.b1C1D1S1N
         explanation fmt =
             "With a minimum hand and no support for partner's spades, bid " ++
              output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
@@ -159,7 +153,6 @@ otherMajorHearts = let
             B.startOfMafia
             B.b1C1D1H
             oppsPass
-            withholdBid B.b1C1D1H1S
         explanation fmt =
             "With no support for partner's hearts but at least 4 spades,\
            \ bid " ++ output fmt (T.Bid 1 T.Spades) ++ " to show that major.\
@@ -178,7 +171,6 @@ otherMajorSpades = let
             B.startOfMafia
             B.b1C1D1S
             oppsPass
-            withholdBid B.b1C1D1S2H
         explanation _ =
             "With a maximum hand, no support for partner's spades, but 5+\
            \ hearts, show that suit in our quest to find a major fit. Partner\
@@ -201,7 +193,6 @@ threeCardSupport = let
             B.startOfMafia
             openerBid
             oppsPass
-            withholdBid responderBid
         explanation fmt =
             "With 3-card support and a non-minimum hand (5-7 HCP), bid " ++
             output fmt (T.Bid 2 T.Diamonds) ++ ". Partner can sign off at the\
@@ -224,7 +215,6 @@ threeCardSupportHearts = let
             B.b1C1D1S
             oppsPass
             suitLength T.Hearts 5
-            withholdBid B.b1C1D1S2D
         explanation fmt =
             "With 3-card spade support and a non-minimum hand (5-7 HCP),\
            \ bid " ++ output fmt (T.Bid 2 T.Diamonds) ++ ". Do this even with\
@@ -243,7 +233,6 @@ maxNoMajors = let
             B.startOfMafia
             openerBid
             oppsPass
-            withholdBid responderBid
         explanation fmt =
             "With a maximum hand but no obvious major fit, respond " ++
             output fmt (T.Bid 2 T.Clubs) ++ ". Opener might bid an\

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -4,7 +4,7 @@ module Topics.StandardModernPrecision.OneClubResponses(
 
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid, forbid, maxSuitLength, makePass, pointRange)
+import Auction(forbid, maxSuitLength, makePass, pointRange)
 import Situation(situation, (<~))
 import CommonBids(cannotPreempt)
 import qualified Terminology as T
@@ -18,7 +18,6 @@ oneDiamond = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C1D
     explanation fmt =
         "When game might not be possible opposite a random 17 HCP, start\
       \ with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ". This initiates MaFiA."
@@ -32,7 +31,6 @@ oneHeart = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C1H
     explanation fmt =
         "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP,\
       \ bid " ++ output fmt (T.Bid 1 T.Hearts) ++ " to show this kind of hand.\
@@ -48,7 +46,6 @@ oneHeartNoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C1Hnos
     explanation fmt =
         "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP\
       \ and no spade suit, bid " ++ output fmt (T.Bid 1 T.Hearts) ++ " to show\
@@ -64,7 +61,6 @@ oneNotrump = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C1N
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, and a balanced\
       \ hand with no 5-card suit. Bid a natural " ++
@@ -80,7 +76,6 @@ oneNotrumpAlt = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C1Nalt
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, and a 5-card\
       \ heart suit. Bid " ++ output fmt (T.Bid 1 T.Notrump) ++ " to show this.\
@@ -110,7 +105,6 @@ slamSingleSuitModified :: Situations
             b1C
             oppsPass
             mapM_ (`maxSuitLength` 4) . filter (/= strain) $ T.allSuits
-            withholdBid bid
         explanation fmt =
             "You've got at least mild slam interest with 12+ HCP, and a 5+ card\
           \ suit. Bid a natural " ++ output fmt (T.Bid level strain) ++ ",\
@@ -130,7 +124,6 @@ twoHeartsBalanced = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C2Halt
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, but a balanced\
       \ hand with no 5-card suit. Bid " ++ output fmt (T.Bid 2 T.Hearts) ++ "\
@@ -164,7 +157,6 @@ oneSpadeGF = let
             b1C
             oppsPass
             pointRange minHcp maxHcp
-            withholdBid B.b1C1Sgf
       in
         situation "1Sgf" action B.b1C1Sgf explanation
   in
@@ -176,7 +168,6 @@ twoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.b1C2S
     explanation fmt =
         "You've got at least mild slam interest with 12+ HCP, but an awkward\
       \ triple-four-one shape. Show this by bidding " ++
@@ -212,7 +203,6 @@ passGameSingleSuit = let
             b1C
             oppsPass
             mapM_ (`maxSuitLength` 4) . filter (/= strain) $ T.allSuits
-            withholdBid bid
         explanation fmt =
             "You're game-forcing with a 5+ card suit. but you're a passed hand,\
           \ so all the slam bids have turned into game bids instead. Bid a\
@@ -236,7 +226,6 @@ passOneNotrump = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.bP1C1N
     explanation fmt =
         "You're a passed hand with game-forcing strength but no 5-card suit.\
       \ Because you're a passed hand, the slam-interest bids are repurposed to\
@@ -259,7 +248,6 @@ passTwoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-        withholdBid B.bP1C2S
     explanation fmt =
         "You're a passed hand with game-forcing strength, but an awkward\
       \ triple-four-one shape. Show this by bidding " ++

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -2,8 +2,8 @@ module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
 import Output(output, Punct(..))
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid, maxSuitLength, minSuitLength, pointRange,
-               displayLastCall, alternatives)
+import Auction(maxSuitLength, minSuitLength, pointRange, displayLastCall,
+               alternatives)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import Topics.StandardModernPrecision.BasicBids(oppsPass, b1D, smpWrapN)
@@ -16,7 +16,6 @@ oneMajor = let
         action = do
             b1D
             oppsPass
-            withholdBid bid
         explanation fmt =
             "Let's start with a natural " ++ displayLastCall fmt bid ++ "\
            \ bid, and see where things go from there."
@@ -36,7 +35,6 @@ twoMinor6M = let
             minSuitLength major 4
             maxSuitLength major 5
             pointRange 14 40
-            withholdBid bid
         explanation _ =
             "With game-forcing strength, a 4- or 5-card major, but a 6+ card\
            \ minor, start by bidding 2 of the minor. There will be time to\
@@ -58,7 +56,6 @@ twoMinorLongInv = let
             maxSuitLength T.Hearts 3
             maxSuitLength T.Spades 3
             pointRange 11 13
-            withholdBid bid
         explanation _ =
             "With invitational strength and a 6-card minor, bid naturally,\
            \ planning to rebid your suit at the 3 level if partner doesn't\
@@ -81,7 +78,6 @@ twoMinorBothInv = let
             maxSuitLength T.Hearts 3
             maxSuitLength T.Spades 3
             pointRange 11 13
-            withholdBid B.b1D2D
         explanation fmt =
             "With invitational strength and both minors, start with " ++
             output fmt (T.Bid 2 T.Diamonds) ++ ", planning to rebid " ++
@@ -101,7 +97,6 @@ reverseFlannery = let
         action = do
             b1D
             oppsPass
-            withholdBid bid
         explanation fmt =
             "With 5 spades, 4 or 5 hearts, and " ++
             (if isInvite then "" else "less than ") ++
@@ -124,7 +119,6 @@ weakMinors54 = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D3C
         explanation fmt =
             "With 5-4 in the minors, no 4-card major, and less than\
            \ invitational strength, bid a pre-emptive-like " ++
@@ -144,7 +138,6 @@ weakMinors55 = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D4C
         explanation fmt =
             "With at least 5-5 in the minors and less than invitational\
            \ strength,\
@@ -164,7 +157,6 @@ notrump1 = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D1N
         explanation fmt =
             "With a balanced hand, no 4-card major, and less than invitational\
            \ strength, bid " ++ output fmt (T.Bid 1 T.Notrump) ++ ". Partner\
@@ -182,7 +174,6 @@ notrump2 = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D2N
         explanation fmt =
             "With a balanced hand, no 4-card major, and 11" ++
              output fmt NDash ++ "12 HCP, bid " ++
@@ -209,7 +200,6 @@ notrump3 = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D3N
         explanation fmt =
             "With a balanced hand, no 4-card major, and 13" ++
             output fmt NDash ++ "16 HCP, bid " ++
@@ -230,7 +220,6 @@ invertedMinors = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D3D
         explanation fmt =
             "With less than invitational strength, no 4-card major, but a long\
            \ diamond suit, jump to " ++ displayLastCall fmt B.b1D3D ++ ", like\
@@ -248,7 +237,6 @@ preempt3M = let
         action = do
             b1D
             oppsPass
-            withholdBid bid
         explanation _ =
             "With a weak hand and a 7-card major, jump to 3 of that suit.\
            \ Opener should pretend that you opened with a pre-empt: they will\
@@ -269,7 +257,6 @@ preempt4D = let
         action = do
             b1D
             oppsPass
-            withholdBid B.b1D4D
         explanation _ =
             "With a weak hand and 8-card support for partner's diamonds, jump\
            \ to 4 of that suit. Opener has at least a doubleton, so on the LoTT\
@@ -277,7 +264,7 @@ preempt4D = let
         -- TODO: not sure that's right. What if you've got a running diamond
         -- suit between the two of you and you belong in a gambling-like 3N?
       in
-        situation "4D" action bid explanation
+        situation "4D" action B.b1D4D explanation
   in
     smpWrapN $ return sit
 -}
@@ -289,7 +276,6 @@ majorGame = let
         action = do
             b1D
             oppsPass
-            withholdBid bid
         explanation _ =
             "With an 8-card major, jump to game. This bid has a very wide\
            \ point range, which makes it difficult for the opponents because\

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -2,7 +2,6 @@ module Topics.StandardModernPrecision.OpeningBids(topic) where
 
 import Output(output)
 import Topic(Topic(..), wrap, Situations)
-import Auction(withholdBid)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified Topics.StandardModernPrecision.BasicBids as B
@@ -12,7 +11,6 @@ oneClub :: Situations
 oneClub = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b1C
     explanation fmt =
         "With 16 or more points (17 or more when balanced), open a strong " ++
         output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of SMP."
@@ -24,7 +22,6 @@ oneDiamond :: Situations
 oneDiamond = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b1D
     explanation fmt =
         "With opening strength but the wrong strength/shape for any other\
       \ opening bid, start with " ++ output fmt (T.Bid 1 T.Diamonds) ++ "."
@@ -37,7 +34,6 @@ oneMajor = let
     sit suit = let
         action = do
             B.firstSeatOpener
-            withholdBid $ B.b1M suit
             -- TODO: What if you're 5-5?
         explanation fmt =
             "With opening strength but not enough for a strong " ++
@@ -54,7 +50,6 @@ oneNotrump :: Situations
 oneNotrump = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b1N
     explanation fmt =
         "With a balanced hand and 14-16 HCP, open " ++
         output fmt (T.Bid 1 T.Notrump) ++ "."
@@ -66,7 +61,6 @@ twoClubs :: Situations
 twoClubs = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b2C
     explanation fmt =
         "With a 6-card club suit, no 5-card major, an opening hand but not a\
        \ hand strong enough to open " ++ output fmt (T.Bid 1 T.Clubs) ++ ",\
@@ -79,7 +73,6 @@ twoDiamonds :: Situations
 twoDiamonds = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b2D
     explanation fmt =
         "The " ++ output fmt (T.Bid 2 T.Diamonds) ++ " hand is that 3-suited\
        \ hand without diamonds, which can be thought of as a 14-card hand with\
@@ -92,7 +85,6 @@ twoNotrump :: Situations
 twoNotrump = let
     action = do
         B.firstSeatOpener
-        withholdBid B.b2N
     explanation fmt =
         "With a balanced hand and 19 to a bad 21 HCP, open " ++
         output fmt (T.Bid 2 T.Notrump) ++ "."

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -4,7 +4,7 @@ import Output(output)
 import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, alternatives, constrain, makePass, makeCall,
-               makeAlertableCall, withholdBid)
+               makeAlertableCall)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
@@ -61,7 +61,6 @@ open :: Situations
 open = let
     action = do
         B.setOpener T.South
-        withholdBid twoDiamondOpener
     explanation fmt =
         "With an opening hand too weak to bid " ++
         output fmt (T.Bid 1 T.Clubs) ++ ", open " ++

--- a/src/Topics/StandardOpeners.hs
+++ b/src/Topics/StandardOpeners.hs
@@ -2,7 +2,7 @@ module Topics.StandardOpeners(topic) where
 
 import Output(output)
 import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
-import Auction(forbid, suitLength, minSuitLength, maxSuitLength, withholdBid)
+import Auction(forbid, suitLength, minSuitLength, maxSuitLength)
 import Situation(situation, (<~))
 import qualified Terminology as T
 import qualified CommonBids as B
@@ -18,7 +18,6 @@ oneNotrump :: Situations
 oneNotrump = let
     action = do
         B.setOpener T.South
-        withholdBid SO.b1n
     explanation fmt =
         "With 15 to 17 HCP and a balanced hand, open a strong " ++
         output fmt (T.Bid 1 T.Notrump) ++ ". No need to plan a second bid;\
@@ -31,7 +30,6 @@ twoNotrump :: Situations
 twoNotrump = let
     action = do
         B.setOpener T.South
-        withholdBid SO.b2n
     explanation fmt =
         "With 20 to 21 HCP and a balanced hand, open " ++
         output fmt (T.Bid 2 T.Notrump) ++ ". No need to plan a second bid;\
@@ -45,7 +43,6 @@ oneSpade = let
     action = do
         B.setOpener T.South
         forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-        withholdBid SO.b1s
     explanation fmt =
         "With a 5-card spade suit and a hand unsuitable for opening \
       \ notrump, open " ++ output fmt (T.Bid 1 T.Spades) ++ "."
@@ -58,7 +55,6 @@ oneHeart = let
     action = do
         B.setOpener T.South
         forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-        withholdBid SO.b1h
     explanation fmt =
         "With a 5-card heart suit and a hand unsuitable for opening \
       \ notrump, open " ++ output fmt (T.Bid 1 T.Hearts) ++ "."
@@ -72,7 +68,6 @@ bothMajorsReverse = let
         B.setOpener T.South
         minSuitLength T.Spades 5
         minSuitLength T.Hearts 5
-        withholdBid SO.b1h
     explanation fmt =
         "With at least 5-5 in the majors and enough strength to reverse,\
       \ open " ++ output fmt (T.Bid 1 T.Hearts) ++ ", planning to rebid " ++
@@ -87,7 +82,6 @@ bothMajorsNoReverse = let
         B.setOpener T.South
         minSuitLength T.Spades 5
         minSuitLength T.Hearts 5
-        withholdBid SO.b1s
     explanation fmt =
         "With at least 5-5 in the majors and not enough strength to\
       \ reverse, open " ++ output fmt (T.Bid 1 T.Spades) ++ ", planning\
@@ -102,7 +96,6 @@ oneDiamond = let
         B.setOpener T.South
         maxSuitLength T.Clubs 3
         minSuitLength T.Diamonds 4
-        withholdBid SO.b1d
     explanation fmt =
         "With no 5-card major and a hand unsuitable for opening \
       \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
@@ -119,7 +112,6 @@ oneDiamond3Cards = let
         suitLength T.Hearts   4
         suitLength T.Diamonds 3
         suitLength T.Clubs    2
-        withholdBid SO.b1d
     explanation fmt =
         "With no 5-card major and a hand unsuitable for opening \
       \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
@@ -136,7 +128,6 @@ oneClub = let
         B.setOpener T.South
         maxSuitLength T.Diamonds 3
         minSuitLength T.Clubs 4
-        withholdBid SO.b1c
     explanation fmt =
         "With no 5-card major and a hand unsuitable for opening \
       \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
@@ -152,7 +143,6 @@ oneClubEqualMinors = let
             B.setOpener T.South
             suitLength T.Diamonds len
             suitLength T.Clubs len
-            withholdBid SO.b1c
         explanation fmt =
             "With no 5-card major and a hand unsuitable for opening \
           \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
@@ -170,7 +160,6 @@ bothMinorsNoReverse = let
         B.setOpener T.South
         minSuitLength T.Diamonds 5
         minSuitLength T.Clubs 5
-        withholdBid SO.b1d
     explanation fmt =
         "With both minors but not enough strength to reverse, open, " ++
         output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
@@ -185,7 +174,6 @@ bothMinorsNoReverseShortD = let
         B.setOpener T.South
         suitLength T.Diamonds 4
         suitLength T.Clubs 5
-        withholdBid SO.b1d
     explanation fmt =
         "With both minors but not enough strength to reverse, open " ++
         output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
@@ -205,7 +193,6 @@ bothMinorsReverse = let
         B.setOpener T.South
         minSuitLength T.Diamonds 5
         minSuitLength T.Clubs 5
-        withholdBid SO.b1c
     explanation fmt =
         "With both minors and enough strength to reverse, open, " ++
         output fmt (T.Bid 1 T.Clubs) ++ ", planning to rebid " ++


### PR DESCRIPTION
Ooh, it feels good to have a PR that removes so many lines!

Now that the answers have type `Action` instead of `CompleteCall`, we can just append them to the end of the `Auction` while withholding the final call. and that means we don't need to explicitly withhold them on every auction!