### PR TITLE
Make it easier to write commentary

### DIFF
--- a/src/Auction.hs
+++ b/src/Auction.hs
@@ -31,7 +31,7 @@ import Data.Bifunctor(first)
 import Data.List.Utils(join)
 
 import DealerProg(DealerProg, addNewReq, addDefn, invert)
-import Output(output, OutputType)
+import Output(Commentary, toCommentary)
 import Structures(Bidding, startBidding, (>-), lastCall, currentBidder)
 import qualified Terminology as T
 
@@ -163,7 +163,7 @@ extractLastCall =
 
 -- displayLastCall is for use in explanations: it formats the most recent call
 -- from an action while stripping out any alerts it might have
-displayLastCall :: OutputType -> Action -> String
-displayLastCall fmt = output fmt . T.removeAlert . extractLastCall
+displayLastCall :: Action -> Commentary
+displayLastCall = toCommentary . T.removeAlert . extractLastCall
 
 -- TODO: hasCard

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -1,3 +1,9 @@
+-- In order to add the String type to the Showable typeclass, we need this
+-- pragma. String is an alias for a list of characters, and the default compiler
+-- doesn't let that be in a type class because not all its arguments are type
+-- variables.
+{-# LANGUAGE FlexibleInstances #-}
+
 module Output (
   Showable
 , toLatex
@@ -6,7 +12,7 @@ module Output (
 , output
 , Punct(..)
 , Commentary(..)
-, toCommentary
+, (.+)
 ) where
 
 import Data.Function((&))
@@ -17,6 +23,20 @@ class Showable a where
     toLatex :: a -> String
     toHtml :: a -> String
     toHtml = undefined -- TODO: remove this later
+    toCommentary :: a -> Commentary
+    toCommentary a = Commentary [flip output a]
+
+
+instance Showable String where
+    toLatex = id
+    toHtml = id
+
+
+-- TODO: remove this when it's no longer needed
+instance Showable (OutputType -> String) where
+    toLatex = toLatex . toCommentary
+    toHtml = toHtml . toCommentary
+    toCommentary a = Commentary [a]
 
 
 data OutputType = LaTeX
@@ -38,10 +58,15 @@ instance Showable Punct where
     toHtml MDash = "&mdash;"
 
 
-data Commentary = Commentary [OutputType -> String]
+newtype Commentary = Commentary [OutputType -> String]
+
+_showableHelper :: OutputType -> Commentary -> String
+_showableHelper o (Commentary c) = join "" . map (o &) $ c
 
 instance Showable Commentary where
-    toLatex (Commentary comments) = join "" . map (LaTeX &) $ comments
+    toLatex = _showableHelper LaTeX
+    toHtml = _showableHelper Html
+    toCommentary = id
 
 instance Semigroup Commentary where
     (Commentary as) <> (Commentary bs) = Commentary (as ++ bs)
@@ -50,5 +75,5 @@ instance Monoid Commentary where
     mempty = Commentary [const ""]
 
 
-toCommentary :: Showable a => a -> Commentary
-toCommentary a = Commentary [flip output a]
+(.+) :: (Showable a, Showable b) => a -> b -> Commentary
+a .+ b = toCommentary a <> toCommentary b

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -5,57 +5,19 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 module Output (
-  Showable
-, toLatex
-, toHtml
-, OutputType(..)
-, output
-, Punct(..)
+  OutputType(..)
 , Commentary(..)
+, Showable(..)
 , (.+)
+, Punct(..)
 ) where
 
 import Data.Function((&))
 import Data.List.Utils(join)
 
 
-class Showable a where
-    -- The minimal definition is either `output` or both `toLatex` and `toHtml`.
-    toLatex :: a -> String
-    toLatex = output LaTeX
-    toHtml :: a -> String
-    toHtml = undefined -- TODO: change this to `output Html` later
-    toCommentary :: a -> Commentary
-    toCommentary a = Commentary [flip output a]
-    output :: OutputType -> a -> String
-    output LaTeX = toLatex
-    output Html = toHtml
-
-
-instance Showable String where
-    toLatex = id
-    toHtml = id
-
-
--- TODO: remove this when it's no longer needed
-instance Showable (OutputType -> String) where
-    toLatex = toLatex . toCommentary
-    toHtml = toHtml . toCommentary
-    toCommentary a = Commentary [a]
-
-
 data OutputType = LaTeX
                 | Html
-
-
-data Punct = NDash
-           | MDash
-
-instance Showable Punct where
-    toLatex NDash = "--"
-    toLatex MDash = "---"
-    toHtml NDash = "&ndash;"
-    toHtml MDash = "&mdash;"
 
 
 newtype Commentary = Commentary [OutputType -> String]
@@ -71,5 +33,38 @@ instance Monoid Commentary where
     mempty = Commentary [const ""]
 
 
+class Showable a where
+    -- The minimal definition is either `output` or both `toLatex` and `toHtml`.
+    toLatex :: a -> String
+    toLatex = output LaTeX
+    toHtml :: a -> String
+    toHtml = undefined -- TODO: change this to `output Html` later
+    output :: OutputType -> a -> String
+    output LaTeX = toLatex
+    output Html = toHtml
+    toCommentary :: a -> Commentary
+    toCommentary a = Commentary [flip output a]
+
+instance Showable String where
+    toLatex = id
+    toHtml = id
+
+-- TODO: remove this when it's no longer needed
+instance Showable (OutputType -> String) where
+    toLatex = toLatex . toCommentary
+    toHtml = toHtml . toCommentary
+    toCommentary a = Commentary [a]
+
+
 (.+) :: (Showable a, Showable b) => a -> b -> Commentary
 a .+ b = toCommentary a <> toCommentary b
+
+
+data Punct = NDash
+           | MDash
+
+instance Showable Punct where
+    toLatex NDash = "--"
+    toLatex MDash = "---"
+    toHtml NDash = "&ndash;"
+    toHtml MDash = "&mdash;"

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -46,14 +46,7 @@ class Showable a where
     toCommentary a = Commentary [flip output a]
 
 instance Showable String where
-    toLatex = id
-    toHtml = id
-
--- TODO: remove this when it's no longer needed
-instance Showable (OutputType -> String) where
-    toLatex = toLatex . toCommentary
-    toHtml = toHtml . toCommentary
-    toCommentary a = Commentary [a]
+    output = flip const
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Commentary

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -17,22 +17,10 @@ class Showable a where
 data OutputType = LaTeX
                 | Html
 
-class Outputtable a where
-    outputWrap :: OutputType -> a -> String
-
-
--- typeclass instances need to be a specific type constructor with arbitrary
--- type variables passed in. This is such a type.
-newtype Wrap a = Wrap {unwrap :: a}
-
-
-instance Showable a => Outputtable (Wrap a) where
-    outputWrap LaTeX = toLatex . unwrap
-    outputWrap Html = toHtml . unwrap
-
 
 output :: (Showable a) => OutputType -> a -> String
-output t = outputWrap t . Wrap
+output LaTeX = toLatex
+output Html = toHtml
 
 
 data Punct = NDash

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -6,6 +6,7 @@ module Output (
 , output
 , Punct(..)
 , Commentary(..)
+, toCommentary
 ) where
 
 import Data.Function((&))
@@ -47,3 +48,7 @@ instance Semigroup Commentary where
 
 instance Monoid Commentary where
     mempty = Commentary [const ""]
+
+
+toCommentary :: Showable a => a -> Commentary
+toCommentary a = Commentary [flip output a]

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -23,7 +23,7 @@ data OutputType = LaTeX
                 | Html
 
 
-output :: (Showable a) => OutputType -> a -> String
+output :: Showable a => OutputType -> a -> String
 output LaTeX = toLatex
 output Html = toHtml
 

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -36,7 +36,14 @@ instance Showable Punct where
     toHtml NDash = "&ndash;"
     toHtml MDash = "&mdash;"
 
+
 data Commentary = Commentary [OutputType -> String]
 
 instance Showable Commentary where
     toLatex (Commentary comments) = join "" . map (LaTeX &) $ comments
+
+instance Semigroup Commentary where
+    (Commentary as) <> (Commentary bs) = Commentary (as ++ bs)
+
+instance Monoid Commentary where
+    mempty = Commentary [const ""]

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -1,6 +1,6 @@
 -- In order to add the String type to the Showable typeclass, we need this
 -- pragma. String is an alias for a list of characters, and the default compiler
--- doesn't let that be in a type class because not all its arguments are type
+-- doesn't let that be in a typeclass because not all its arguments are type
 -- variables.
 {-# LANGUAGE FlexibleInstances #-}
 

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -20,11 +20,16 @@ import Data.List.Utils(join)
 
 
 class Showable a where
+    -- The minimal definition is either `output` or both `toLatex` and `toHtml`.
     toLatex :: a -> String
+    toLatex = output LaTeX
     toHtml :: a -> String
-    toHtml = undefined -- TODO: remove this later
+    toHtml = undefined -- TODO: change this to `output Html` later
     toCommentary :: a -> Commentary
     toCommentary a = Commentary [flip output a]
+    output :: OutputType -> a -> String
+    output LaTeX = toLatex
+    output Html = toHtml
 
 
 instance Showable String where
@@ -43,11 +48,6 @@ data OutputType = LaTeX
                 | Html
 
 
-output :: Showable a => OutputType -> a -> String
-output LaTeX = toLatex
-output Html = toHtml
-
-
 data Punct = NDash
            | MDash
 
@@ -60,12 +60,8 @@ instance Showable Punct where
 
 newtype Commentary = Commentary [OutputType -> String]
 
-_showableHelper :: OutputType -> Commentary -> String
-_showableHelper o (Commentary c) = join "" . map (o &) $ c
-
 instance Showable Commentary where
-    toLatex = _showableHelper LaTeX
-    toHtml = _showableHelper Html
+    output o (Commentary c) = join "" . map (o &) $ c
     toCommentary = id
 
 instance Semigroup Commentary where

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -5,8 +5,12 @@ module Output (
 , OutputType(..)
 , output
 , Punct(..)
-, Commentary
+, Commentary(..)
 ) where
+
+import Data.Function((&))
+import Data.List.Utils(join)
+
 
 class Showable a where
     toLatex :: a -> String
@@ -32,4 +36,7 @@ instance Showable Punct where
     toHtml NDash = "&ndash;"
     toHtml MDash = "&mdash;"
 
-type Commentary = OutputType -> String
+data Commentary = Commentary [OutputType -> String]
+
+instance Showable Commentary where
+    toLatex (Commentary comments) = join "" . map (LaTeX &) $ comments

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -22,10 +22,6 @@ data OutputType = LaTeX
 
 newtype Commentary = Commentary [OutputType -> String]
 
-instance Showable Commentary where
-    output o (Commentary c) = join "" . map (o &) $ c
-    toCommentary = id
-
 instance Semigroup Commentary where
     (Commentary as) <> (Commentary bs) = Commentary (as ++ bs)
 
@@ -47,6 +43,10 @@ class Showable a where
 
 instance Showable String where
     output = flip const
+
+instance Showable Commentary where
+    output o (Commentary c) = join "" . map (o &) $ c
+    toCommentary = id
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Commentary

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -13,7 +13,6 @@ module Output (
 ) where
 
 import Data.Function((&))
-import Data.List.Utils(join)
 
 
 data OutputType = LaTeX
@@ -45,7 +44,7 @@ instance Showable String where
     output = flip const
 
 instance Showable Commentary where
-    output o (Commentary c) = join "" . map (o &) $ c
+    output o (Commentary c) = concatMap (o &) $ c
     toCommentary = id
 
 

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -11,7 +11,7 @@ import System.Random(StdGen)
 
 import Auction(Action, finish, extractLastCall, withholdBid)
 import DealerProg(DealerProg)
-import Output(Commentary)
+import Output(OutputType, Commentary(..))
 import Random(pickItem)
 import Structures(Bidding)
 import Terminology(CompleteCall, Direction, Vulnerability)
@@ -24,12 +24,13 @@ data Situation = Situation String Bidding DealerProg CompleteCall Commentary
 -- of auction whose last bid is the intended answer to the situation. We make
 -- this a convenience, so you can reuse Actions for both constructing the
 -- auction and describing the next action that should follow.
-situation :: String -> Action -> Action -> Commentary -> Vulnerability ->
-    Direction -> Situation
-situation r a c s v d = Situation r bidding deal answer s v d
+situation :: String -> Action -> Action -> (OutputType -> String) ->
+    Vulnerability -> Direction -> Situation
+situation r a c s v d = Situation r bidding deal answer commentary v d
   where
     (bidding, deal) = finish d (a >> withholdBid c)
     answer = extractLastCall c
+    commentary = Commentary [s]
 
 
 sitRef :: Situation -> String

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -11,7 +11,7 @@ import System.Random(StdGen)
 
 import Auction(Action, finish, extractLastCall, withholdBid)
 import DealerProg(DealerProg)
-import Output(Showable, Commentary, (.+))
+import Output(Showable, Commentary, toCommentary)
 import Random(pickItem)
 import Structures(Bidding)
 import Terminology(CompleteCall, Direction, Vulnerability)
@@ -26,7 +26,7 @@ data Situation = Situation String Bidding DealerProg CompleteCall Commentary
 -- auction and describing the next action that should follow.
 situation :: Showable s => String -> Action -> Action -> s -> Vulnerability ->
     Direction -> Situation
-situation r a c s v d = Situation r bidding deal answer ("" .+ s) v d
+situation r a c s v d = Situation r bidding deal answer (toCommentary s) v d
   where
     (bidding, deal) = finish d (a >> withholdBid c)
     answer = extractLastCall c

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -11,7 +11,7 @@ import System.Random(StdGen)
 
 import Auction(Action, finish, extractLastCall, withholdBid)
 import DealerProg(DealerProg)
-import Output(Showable, Commentary(..), (.+))
+import Output(Showable, Commentary, (.+))
 import Random(pickItem)
 import Structures(Bidding)
 import Terminology(CompleteCall, Direction, Vulnerability)

--- a/src/Situation.hs
+++ b/src/Situation.hs
@@ -11,7 +11,7 @@ import System.Random(StdGen)
 
 import Auction(Action, finish, extractLastCall, withholdBid)
 import DealerProg(DealerProg)
-import Output(OutputType, Commentary(..))
+import Output(Showable, Commentary(..), (.+))
 import Random(pickItem)
 import Structures(Bidding)
 import Terminology(CompleteCall, Direction, Vulnerability)
@@ -24,13 +24,12 @@ data Situation = Situation String Bidding DealerProg CompleteCall Commentary
 -- of auction whose last bid is the intended answer to the situation. We make
 -- this a convenience, so you can reuse Actions for both constructing the
 -- auction and describing the next action that should follow.
-situation :: String -> Action -> Action -> (OutputType -> String) ->
-    Vulnerability -> Direction -> Situation
-situation r a c s v d = Situation r bidding deal answer commentary v d
+situation :: Showable s => String -> Action -> Action -> s -> Vulnerability ->
+    Direction -> Situation
+situation r a c s v d = Situation r bidding deal answer ("" .+ s) v d
   where
     (bidding, deal) = finish d (a >> withholdBid c)
     answer = extractLastCall c
-    commentary = Commentary [s]
 
 
 sitRef :: Situation -> String

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -10,7 +10,7 @@ import Data.List.Utils(join)
 import System.Random(StdGen, genWord64)
 
 import DealerProg(eval)
-import Output(Showable, toLatex, OutputType(..), Commentary)
+import Output(Showable, toLatex, Commentary)
 import Situation(Situation(..))
 import Structures(Bidding, Deal)
 import Terminology(CompleteCall)
@@ -23,7 +23,7 @@ data SituationInstance =
 instance Showable SituationInstance where
     toLatex (SituationInstance b c s d ds) =
         "\\problem{%\n" ++
-            join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, s LaTeX, ds] ++
+            join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, toLatex s, ds] ++
             "%\n}"
 
 

--- a/src/Topics/JacobyTransfers.hs
+++ b/src/Topics/JacobyTransfers.hs
@@ -1,6 +1,6 @@
 module Topics.JacobyTransfers(topic) where
 
-import Output(output, Punct(NDash))
+import Output(Punct(NDash), (.+))
 import Topic(Topic(..), Situations, wrap, stdWrap, wrapVulDlr)
 import Auction(forbid, makeCall, makeAlertableCall, makePass, pointRange,
                suitLength, minSuitLength, Action, balancedHand, constrain)
@@ -97,12 +97,13 @@ initiateTransferWeak = let
             setUpTransfer suit
             pointRange 0 7
             forbid equalMajors  -- With 5-5 in the majors, pick the better one.
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". You have\
-           \ such a weak hand that you have no interest in game, but you do have\
-           \ a 5-card major. Playing in it, even if it's a 5-2 fit, is more\
-           \ likely to succeed than playing in notrump. Make a Jacoby transfer\
-           \ into the suit, then pass and leave partner at the 2 level."
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". You have\
+           \ such a weak hand that you have no interest in game, but you do\
+           \ have a 5-card major. Playing in it, even if it's a 5-2 fit, is\
+           \ more likely to succeed than playing in notrump. Make a Jacoby\
+           \ transfer into the suit, then pass and leave partner at the 2\
+           \ level."
         bid = jacobyTransfer suit
       in
         situation "InitWeak" action bid explanation
@@ -118,13 +119,13 @@ initiateTransferBInv = let
             pointRange 8 9
             forbid equalMajors
             balancedHand
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". You have\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". You have\
            \ a balanced hand with invitational strength, and a 5-card major.\
-           \ Make a Jacoby transfer into the suit, then bid " ++
-             output fmt (T.Bid 2 T.Notrump) ++ ". This gives partner the\
-           \ options of playing in notrump with 2-card " ++ init (show suit) ++
-             " support or in " ++ show suit ++ " with a fit, and the option of\
+           \ Make a Jacoby transfer into the suit, then bid " .+
+             T.Bid 2 T.Notrump .+ ". This gives partner the\
+           \ options of playing in notrump with 2-card " .+ init (show suit) .+
+             " support or in " .+ show suit .+ " with a fit, and the option of\
            \ playing in partscore with a minimum hand and game with a maximum."
         bid = jacobyTransfer suit
       in
@@ -141,14 +142,14 @@ initiateTransferBGf = let
             pointRange 10 14
             forbid equalMajors
             balancedHand
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". You have\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". You have\
            \ a balanced hand with game-going but not slam-going strength, and a\
-           \ 5-card major. Make a Jacoby transfer into the suit, then bid " ++
-             output fmt (T.Bid 3 T.Notrump) ++ ". This gives partner the\
-           \ options of passing and playing in notrump with 2-card " ++
-             init (show suit) ++ " support or correcting to " ++
-             output fmt (T.Bid 4 suit) ++ " with a fit, knowing that you\
+           \ 5-card major. Make a Jacoby transfer into the suit, then bid " .+
+             T.Bid 3 T.Notrump .+ ". This gives partner the\
+           \ options of passing and playing in notrump with 2-card " .+
+             init (show suit) .+ " support or correcting to " .+
+             T.Bid 4 suit .+ " with a fit, knowing that you\
            \ belong in game but not slam."
         bid = jacobyTransfer suit
       in
@@ -163,8 +164,8 @@ completeTransfer = let
         action = do
             setUpCompletion suit
             minSuitLength suit 3
-        explanation fmt =
-            "You have opened a strong " ++ output fmt oneNT ++ ", and partner\
+        explanation =
+            "You have opened a strong " .+ oneNT .+ ", and partner\
           \ has made a Jacoby transfer. Complete the transfer by bidding the\
           \ next higher suit. Partner promises at least 5 cards in that major,\
           \ but wants you to be declarer so your stronger hand stays hidden."
@@ -181,13 +182,13 @@ completeTransferShort = let
         action = do
             setUpCompletion suit
             suitLength suit 2
-        explanation fmt =
-            "You have opened a strong " ++ output fmt oneNT ++ ", and partner\
-          \ has made a Jacoby transfer, indicating they have at least 5 " ++
-            show suit ++ ". Even though you only have 2-card support, complete\
+        explanation =
+            "You have opened a strong " .+ oneNT .+ ", and partner\
+          \ has made a Jacoby transfer, indicating they have at least 5 " .+
+            suit .+ ". Even though you only have 2-card support, complete\
           \ the transfer by bidding the next higher suit. You have at least a\
-          \ 7-card fit. If partner is very weak, " ++
-            output fmt (T.Bid 2 suit) ++ " rates to play better than notrump,\
+          \ 7-card fit. If partner is very weak, " .+
+            T.Bid 2 suit .+ " rates to play better than notrump,\
           \ and you want to be declarer so that your strong hand stays hidden.\
           \ If partner has at least invitational strength, he will make\
           \ another bid to give you options of where to play."
@@ -207,14 +208,13 @@ majors55inv = let
         suitLength T.Hearts 5
         suitLength T.Spades 5
         pointRange 7 9
-    explanation fmt =
-        "Partner has opened a strong " ++ output fmt oneNT ++ ". With 5" ++
-        output fmt NDash ++ "5 in\
+    explanation =
+        "Partner has opened a strong " .+ oneNT .+ ". With 5" .+ NDash .+ "5 in\
       \ the majors and invitational strength, first make a Jacoby transfer\
-      \ into hearts, and then bid " ++ output fmt (T.Bid 2 T.Spades) ++ "\
-      \ afterwards. Partner will then have the options of passing " ++
-        output fmt (T.Bid 2 T.Spades) ++ " with a minimum hand and a spade\
-      \ fit, bidding " ++ output fmt (T.Bid 3 T.Hearts) ++ " with a minimum\
+      \ into hearts, and then bid " .+ T.Bid 2 T.Spades .+ "\
+      \ afterwards. Partner will then have the options of passing " .+
+        T.Bid 2 T.Spades .+ " with a minimum hand and a spade\
+      \ fit, bidding " .+ T.Bid 3 T.Hearts .+ " with a minimum\
       \ hand and no spade fit (in which case a heart fit is guaranteed), or\
       \ bidding one of the majors at the 4 level with a maximum. This\
       \ wrong-sides the contract if we end up playing in spades."
@@ -233,12 +233,11 @@ majors55gf = let
             suitLength T.Hearts 5
             suitLength T.Spades 5
             pointRange 10 14
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". With 5" ++
-            output fmt NDash ++ "5 in\
-            \ the majors and\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". With 5" .+
+            NDash .+ "5 in the majors and\
             \ game-forcing strength, first make a Jacoby transfer into spades,\
-            \ and then bid " ++ output fmt (T.Bid 3 T.Hearts) ++ " afterwards.\
+            \ and then bid " .+ T.Bid 3 T.Hearts .+ " afterwards.\
             \ Partner will then have the options of which game to bid.\
             \ This wrong-sides the contract if we end up playing in hearts."
         bid = jacobyTransfer T.Spades

--- a/src/Topics/MinorTransfersScott.hs
+++ b/src/Topics/MinorTransfersScott.hs
@@ -1,6 +1,6 @@
 module Topics.MinorTransfersScott(topic) where
 
-import Output(output)
+import Output((.+))
 import Topic(Topic(..), Situations, wrap)
 import Auction(forbid, makeCall, makeAlertableCall, makePass, pointRange,
                hasTopN, constrain, minSuitLength, maxSuitLength, Action,
@@ -85,8 +85,8 @@ initiateTransfer = let
     sit suit = let
         action = do
             setUpTransfer suit
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". You have\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". You have\
            \ an unbalaned hand with a long minor. Bid 2 steps below your suit\
            \ to transfer into it and make your partner declarer so their\
            \ stronger hand stays hidden."
@@ -104,9 +104,9 @@ completeTransfer = let
         action = do
             setUpCompletion suit
             forbid (canSuperaccept suit)
-        explanation fmt =
-            "You have opened a strong " ++ output fmt oneNT ++ ", and partner\
-          \ has made a minor suit transfer into " ++ show suit ++ ". You need\
+        explanation =
+            "You have opened a strong " .+ oneNT .+ ", and partner\
+          \ has made a minor suit transfer into " .+ suit .+ ". You need\
           \ at least 3-card support including 1 of the top 2 cards to\
           \ superaccept, so just accept the transfer regularly and bid the\
           \ suit."
@@ -124,15 +124,15 @@ superacceptTransfer = let
         action = do
             setUpCompletion suit
             canSuperaccept suit
-        explanation fmt =
-            "You have opened a strong " ++ output fmt oneNT ++ ", and partner\
-          \ has made a minor suit transfer into " ++ show suit ++ ". You have\
+        explanation =
+            "You have opened a strong " .+ oneNT .+ ", and partner\
+          \ has made a minor suit transfer into " .+ suit .+ ". You have\
           \ at least 3-card support including 1 of the top 2 honors,\
           \ so superaccept the transfer by bidding 1 step up from\
           \ the transfer (1 step under the intended suit). This gives partner\
-          \ the option of bidding " ++ output fmt (T.Bid 3 T.Notrump) ++ " if\
-          \ they think the suit will run, and wrong-siding the " ++
-            output fmt (T.Bid 3 suit) ++ " contract if it won't."
+          \ the option of bidding " .+ T.Bid 3 T.Notrump .+ " if\
+          \ they think the suit will run, and wrong-siding the " .+
+            T.Bid 3 suit .+ " contract if it won't."
         bid = setUpSuperacceptCompletion suit
       in
         situation "SupAcc" action bid explanation
@@ -148,12 +148,12 @@ completeSuperacceptAKQ = let
             setUpSuperacceptCompletion suit
             hasTopN suit 3 2
             pointRange 0 7  -- Not a situation where you'd naively bid 3N!
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ", you have\
-          \ made a minor suit transfer in " ++ show suit ++ ", and partner has\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ", you have\
+          \ made a minor suit transfer in " .+ suit .+ ", and partner has\
           \ superaccepted the transfer, showing at least 3-card support and\
           \ either the ace or king of the suit. The suit is running, so bid\
-          \ a thin " ++ output fmt (T.Bid 3 T.Notrump) ++ ". If opener has a\
+          \ a thin " .+ T.Bid 3 T.Notrump .+ ". If opener has a\
           \ stopper in every other suit, the game is likely be makable,\
           \ despite your lack of points."
         bid = makeCall $ T.Bid 3 T.Notrump
@@ -172,13 +172,13 @@ completeSuperacceptKQJ10 = let
             forbid (hasTopN suit 3 2)
             hasTopN suit 5 3
             pointRange 0 7  -- Not a situation where you'd naively bid 3N!
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ", you have\
-          \ made a minor suit transfer in " ++ show suit ++ ", and partner has\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ", you have\
+          \ made a minor suit transfer in " .+ suit .+ ", and partner has\
           \ superaccepted the transfer, showing at least 3-card support and\
           \ either the ace or king of the suit. Although you don't have all\
           \ three top honors, you've got 4 of the top 5, so the suit is very\
-          \ likely to run.  Bid a thin " ++ output fmt (T.Bid 3 T.Notrump) ++
+          \ likely to run.  Bid a thin " .+ T.Bid 3 T.Notrump .+
             ". If opener has a stopper in every other suit, the game is likely\
           \ be makable, despite your lack of points."
         bid = makeCall $ T.Bid 3 T.Notrump
@@ -197,9 +197,9 @@ completeSuperaccept10CardFit = let
             hasTopN suit 2 1
             pointRange 0 7  -- Not a situation where you'd normally bid 3N!
             minSuitLength suit 7
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ", you have\
-          \ made a minor suit transfer in " ++ show suit ++ ", and partner has\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ", you have\
+          \ made a minor suit transfer in " .+ suit .+ ", and partner has\
           \ superaccepted the transfer, showing at least 3-card support and\
           \ either the ace or king of the suit. With your extra length and\
           \ both top honors, the suit should be running. Bid the notrump\
@@ -220,9 +220,9 @@ failSuperaccept = let
             forbid (hasTopN suit 2 1)
             forbid (hasTopN suit 5 3)
             pointRange 0 7  -- SKip invitational hands; there's too much nuance
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ", you have\
-          \ made a minor suit transfer in " ++ show suit ++ ", and partner has\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ", you have\
+          \ made a minor suit transfer in " .+ suit .+ ", and partner has\
           \ superaccepted the transfer, showing at least 3-card support and\
           \ either the ace or king of the suit. Despite the fit, it doesn't\
           \ look like the suit is going to run, so a notrump game probably\
@@ -247,16 +247,16 @@ notrumpInvite = let
             maxSuitLength T.Spades 3
             maxSuitLength T.Hearts 3
             pointRange 8 9
-        explanation fmt =
-            "Partner has opened a strong " ++ output fmt oneNT ++ ". You have\
+        explanation =
+            "Partner has opened a strong " .+ oneNT .+ ". You have\
           \ a balanced hand with invitational strength. Even though you don't\
-          \ have a 4-card major, bid " ++ output fmt (T.Bid 2 T.Clubs) ++ "\
-          \ as Stayman, intending to rebid " ++ output fmt (T.Bid 2 T.Notrump)
-            ++ " regardless of the reply. Note that the " ++
-            output fmt (T.Bid 2 T.Notrump) ++ " bid is alertable and should\
+          \ have a 4-card major, bid " .+ T.Bid 2 T.Clubs .+ "\
+          \ as Stayman, intending to rebid " .+ T.Bid 2 T.Notrump
+            .+ " regardless of the reply. Note that the " .+
+            T.Bid 2 T.Notrump .+ " bid is alertable and should\
           \ be described as indicating that you might not have a 4-card major.\
-          \ The Stayman bid is not alertable. This frees up a direct " ++
-            output fmt (T.Bid 2 T.Notrump) ++ " reply to be a minor suit\
+          \ The Stayman bid is not alertable. This frees up a direct " .+
+            T.Bid 2 T.Notrump .+ " reply to be a minor suit\
           \ transfer."
         bid = makeCall $ T.Bid 2 T.Clubs
       in

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.Mafia(topic) where
 
-import Output(output, Punct(..), (.+))
+import Output(Punct(..), (.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(forbid, minSuitLength, suitLength, balancedHand, equalLength,
                longerThan, displayLastCall)
@@ -120,10 +120,10 @@ bothMajorsLongSpades = let
             forbid balancedHand
             minSuitLength T.Hearts 4
             T.Spades `longerThan` T.Hearts
-        explanation fmt =
-            "With both majors but longer spades, start by bidding " ++
-            output fmt (T.Bid 1 T.Spades) ++ ". You can then bid the hearts\
-           \ later without reversing."
+        explanation =
+            "With both majors but longer spades, start by bidding " .+
+            T.Bid 1 T.Spades .+ ". You can then bid the hearts later without\
+          \ reversing."
       in
         situation "2MS" action B.b1C1D1S explanation
   in

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -15,7 +15,7 @@ notrump = let
     sit bid = let
         action = do
             B.startOfMafia
-        explanation _ =
+        explanation =
             "With a balanced hand, rebid notrump to show your point range.\
            \ Even if you have a 5-card major, it's better to know that\
            \ systems are on and partner knows your strength within 1 HCP."
@@ -31,7 +31,7 @@ oneMajor = let
         action = do
             B.startOfMafia
             forbid balancedHand
-        explanation _ =
+        explanation =
             "With an unbalanced hand that isn't game forcing, bid a 4-card\
            \ major if you have one."
       in
@@ -48,7 +48,7 @@ oneMajorMinor = let
             forbid balancedHand
             minSuitLength minorSuit 5
             suitLength majorSuit 4
-        explanation _ =
+        explanation =
             "With an unbalanced hand that isn't game forcing, bid a 4-card\
            \ major if you have one. This holds even if you've got a longer\
            \ minor (MAjors FIrst Always)."
@@ -66,7 +66,7 @@ twoMinorSingle = let
             B.startOfMafia
             forbid balancedHand
             minSuitLength minorSuit 6
-        explanation _ =
+        explanation =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, bid your long minor."
       in
@@ -84,7 +84,7 @@ twoMinorMinors = let
             suitLength minorSuit 5
             -- The answer Action also ensures that the minor we bid is longer
             -- than the minor we don't bid.
-        explanation _ =
+        explanation =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, rebid your long minor. Sometimes this minor is\
            \ only 5 cards, if you're 5-4 in the minors."
@@ -101,7 +101,7 @@ equalMinors = let
             B.startOfMafia
             forbid balancedHand
             T.Clubs `equalLength` T.Diamonds
-        explanation _ =
+        explanation =
             "With an unbalanced hand that isn't game forcing and doesn't have\
            \ a 4-card major, rebid your long minor. When the minors are the\
            \ same length, bid diamonds first so that you can bid clubs later\

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.Mafia(topic) where
 
-import Output(output, Punct(..))
+import Output(output, Punct(..), (.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(forbid, minSuitLength, suitLength, balancedHand, equalLength,
                longerThan, displayLastCall)
@@ -135,13 +135,11 @@ jumpBid = let
     sit bid = let
         action = do
             B.startOfMafia
-        explanation fmt =
+        explanation =
             "With an unbalanced hand that is strong enough to\
            \ force to game, jump in your suit. Responder can treat this like\
-           \ the 2/1 sequence " ++
-            output fmt (T.Bid 2 T.Clubs) ++ output fmt NDash ++
-            output fmt (T.Bid 2 T.Diamonds) ++ output fmt NDash ++
-            displayLastCall fmt bid ++ "."
+           \ the 2/1 sequence " .+ T.Bid 2 T.Clubs .+ NDash .+
+            T.Bid 2 T.Diamonds .+ NDash .+ displayLastCall bid .+ "."
       in
         situation "J1" action bid explanation
   in

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.MafiaResponses(topic) where
 
-import Output(output)
+import Output((.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(Action, suitLength, maxSuitLength)
 import Situation(Situation, situation, (<~))
@@ -40,10 +40,10 @@ maxSupportSemibalanced = let
             B.startOfMafia
             openerBid
             oppsPass
-        explanation fmt =
+        explanation =
             "With 4-card support and a maximum hand but no singleton, invite\
            \ with a double raise. You've already shown that game might not be\
-           \ possible with your " ++ output fmt (T.Bid 1 T.Diamonds) ++ " bid,\
+           \ possible with your " .+ T.Bid 1 T.Diamonds .+ " bid,\
            \ so partner won't get too excited."
       in
         situation "3MB" action responderBid explanation
@@ -62,12 +62,12 @@ maxSupportUnbalanced = let
             B.startOfMafia
             openerBid
             oppsPass
-        explanation fmt =
+        explanation =
             "With 4-card support, a maximum hand, and a singleton or void,\
-           \ make a mini-splinter bid with " ++
-             output fmt (T.Bid 2 T.Notrump) ++ ". Partner can\
-           \ either sign off in our major (in partscore or game), or bid " ++
-            output fmt (T.Bid 3 T.Clubs) ++ " to ask\
+           \ make a mini-splinter bid with " .+
+             T.Bid 2 T.Notrump .+ ". Partner can\
+           \ either sign off in our major (in partscore or game), or bid " .+
+             T.Bid 3 T.Clubs .+ " to ask\
            \ us to bid our singleton. Remember that you can bid the\
            \ singleton/void ``naturally'' unless it's clubs, in which case bid\
            \ our trump suit to show it!"
@@ -85,13 +85,13 @@ brakesHearts = let
             B.startOfMafia
             B.b1C1D1H
             oppsPass
-        explanation fmt =
-            "With neither major and a non-maximum hand, bid " ++
-             output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
+        explanation =
+            "With neither major and a non-maximum hand, bid " .+
+             T.Bid 1 T.Notrump .+ " as the ``double negative''\
            \ brake bid. Unless partner makes a jump bid, seriously consider\
            \ passing whatever they do next (if they do anything at all;\
-           \ perhaps they'll prefer playing in " ++
-             output fmt (T.Bid 1 T.Notrump) ++ " itself, since your bid is\
+           \ perhaps they'll prefer playing in " .+
+             T.Bid 1 T.Notrump .+ " itself, since your bid is\
            \ not forcing)."
       in
         situation "1NH" action B.b1C1D1H1N explanation
@@ -107,13 +107,13 @@ brakesSpades = let
             B.b1C1D1S
             oppsPass
             maxSuitLength T.Hearts 4
-        explanation fmt =
-            "With a minimum hand and no support for partner's spades, bid " ++
-             output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
+        explanation =
+            "With a minimum hand and no support for partner's spades, bid " .+
+             T.Bid 1 T.Notrump .+ " as the ``double negative''\
            \ brake bid. Unless partner makes a jump bid, seriously consider\
            \ passing whatever they do next (if they do anything at all;\
-           \ perhaps they'll prefer playing in " ++
-             output fmt (T.Bid 1 T.Notrump) ++ " itself, since your bid is\
+           \ perhaps they'll prefer playing in " .+
+             T.Bid 1 T.Notrump .+ " itself, since your bid is\
            \ not forcing)."
       in
         situation "1NS" action B.b1C1D1S1N explanation
@@ -129,16 +129,16 @@ brakesSpadesHearts = let
             B.b1C1D1S
             oppsPass
             suitLength T.Hearts 5
-        explanation fmt =
-            "With a minimum hand and no support for partner's spades, bid " ++
-             output fmt (T.Bid 1 T.Notrump) ++ " as the ``double negative''\
-           \ brake bid. Do this even if you've got a heart suit! Partner's " ++
-             output fmt (T.Bid 1 T.Spades) ++ " bid has denied 4 hearts, and\
+        explanation =
+            "With a minimum hand and no support for partner's spades, bid " .+
+             T.Bid 1 T.Notrump .+ " as the ``double negative''\
+           \ brake bid. Do this even if you've got a heart suit! Partner's " .+
+             T.Bid 1 T.Spades .+ " bid has denied 4 hearts, and\
            \ although we might have a 5-3 fit, you're too weak to risk getting\
            \ stuck at the 3 level if we don't have such a fit. Unless partner\
            \ makes a jump bid, seriously consider passing whatever they do\
            \ next (if they do anything at all; perhaps they'll prefer playing\
-           \ in " ++ output fmt (T.Bid 1 T.Notrump) ++ " itself, since your\
+           \ in " .+ T.Bid 1 T.Notrump .+ " itself, since your\
            \ bid is not forcing)."
       in
         situation "1NSH" action B.b1C1D1S1N explanation
@@ -153,9 +153,9 @@ otherMajorHearts = let
             B.startOfMafia
             B.b1C1D1H
             oppsPass
-        explanation fmt =
+        explanation =
             "With no support for partner's hearts but at least 4 spades,\
-           \ bid " ++ output fmt (T.Bid 1 T.Spades) ++ " to show that major.\
+           \ bid " .+ T.Bid 1 T.Spades .+ " to show that major.\
            \ Because we're still at the 1 level, you can do this with any\
            \ strength hand, even a 0 count!"
       in
@@ -193,12 +193,12 @@ threeCardSupport = let
             B.startOfMafia
             openerBid
             oppsPass
-        explanation fmt =
-            "With 3-card support and a non-minimum hand (5-7 HCP), bid " ++
-            output fmt (T.Bid 2 T.Diamonds) ++ ". Partner can sign off at the\
+        explanation =
+            "With 3-card support and a non-minimum hand (5-7 HCP), bid " .+
+            T.Bid 2 T.Diamonds .+ ". Partner can sign off at the\
            \ 2 level with a 7-card fit, invite with an 8-card fit, or bid\
            \ other suits naturally (minor suits must be 6 cards long). Note\
-           \ that partner's " ++ output fmt (T.Bid 2 T.Notrump) ++ " is an\
+           \ that partner's " .+ T.Bid 2 T.Notrump .+ " is an\
            \ artificial game force."
       in
         situation "2D" action responderBid explanation
@@ -215,10 +215,10 @@ threeCardSupportHearts = let
             B.b1C1D1S
             oppsPass
             suitLength T.Hearts 5
-        explanation fmt =
+        explanation =
             "With 3-card spade support and a non-minimum hand (5-7 HCP),\
-           \ bid " ++ output fmt (T.Bid 2 T.Diamonds) ++ ". Do this even with\
-           \ a 5-card heart suit!"
+           \ bid " .+ T.Bid 2 T.Diamonds .+ ". Do this even with a 5-card\
+           \ heart suit!"
       in
         situation "2D" action B.b1C1D1S2D explanation
   in
@@ -233,13 +233,13 @@ maxNoMajors = let
             B.startOfMafia
             openerBid
             oppsPass
-        explanation fmt =
-            "With a maximum hand but no obvious major fit, respond " ++
-            output fmt (T.Bid 2 T.Clubs) ++ ". Opener might bid an\
-           \ artificial " ++ output fmt (T.Bid 2 T.Diamonds) ++ " to show a\
+        explanation =
+            "With a maximum hand but no obvious major fit, respond " .+
+            T.Bid 2 T.Clubs .+ ". Opener might bid an\
+           \ artificial " .+ T.Bid 2 T.Diamonds .+ " to show a\
            \ misfit where we're scrambling for partscore, or bid a natural\
-           \ suit (6-card minor, 4 cards in the other major), or " ++
-            output fmt (T.Bid 2 T.Notrump) ++ " as an artificial game\
+           \ suit (6-card minor, 4 cards in the other major), or " .+
+            T.Bid 2 T.Notrump .+ " as an artificial game\
            \ force/waiting bid."
       in
         situation "2C" action responderBid explanation

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -19,7 +19,7 @@ minSupport = let
             B.startOfMafia
             openerBid
             oppsPass
-        explanation _ =
+        explanation =
             "With 4-card support and a minimum hand, raise partner's major.\
            \ You are neither strong enough nor shapely enough to invite to\
            \ game."
@@ -171,7 +171,7 @@ otherMajorSpades = let
             B.startOfMafia
             B.b1C1D1S
             oppsPass
-        explanation _ =
+        explanation =
             "With a maximum hand, no support for partner's spades, but 5+\
            \ hearts, show that suit in our quest to find a major fit. Partner\
            \ has already denied 4 hearts (unless they're at least 5-4 in the\

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -2,7 +2,7 @@ module Topics.StandardModernPrecision.OneClubResponses(
   topic
 , topicExtras) where
 
-import Output(output, Punct(..))
+import Output(Punct(..), (.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(forbid, maxSuitLength, makePass, pointRange)
 import Situation(situation, (<~))
@@ -18,9 +18,9 @@ oneDiamond = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "When game might not be possible opposite a random 17 HCP, start\
-      \ with " ++ output fmt (T.Bid 1 T.Diamonds) ++ ". This initiates MaFiA."
+      \ with " .+ T.Bid 1 T.Diamonds .+ ". This initiates MaFiA."
   in
     smpWrapN . return $ situation "1D" action B.b1C1D explanation
 
@@ -31,9 +31,9 @@ oneHeart = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP,\
-      \ bid " ++ output fmt (T.Bid 1 T.Hearts) ++ " to show this kind of hand.\
+      \ bid " .+ T.Bid 1 T.Hearts .+ " to show this kind of hand.\
       \ Subsequent bids are natural 5-card suits (and later 4-card suits), not\
       \ MaFiA."
   in
@@ -46,9 +46,9 @@ oneHeartNoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got a game-forcing hand but slam is unlikely. With 8 to 11 HCP\
-      \ and no spade suit, bid " ++ output fmt (T.Bid 1 T.Hearts) ++ " to show\
+      \ and no spade suit, bid " .+ T.Bid 1 T.Hearts .+ " to show\
       \ this kind of hand. Partner's rebid will be a natural 5-card suit, not\
       \ MaFiA."
   in
@@ -61,11 +61,10 @@ oneNotrump = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got at least mild slam interest with 12+ HCP, and a balanced\
-      \ hand with no 5-card suit. Bid a natural " ++
-        output fmt (T.Bid 1 T.Notrump) ++ ", and we'll\
-      \ go from there. Stayman is on, but transfers are not."
+      \ hand with no 5-card suit. Bid a natural " .+ T.Bid 1 T.Notrump .+ ",\
+      \ and we'll go from there. Stayman is on, but transfers are not."
   in
     smpWrapN . return $ situation "1N" action B.b1C1N explanation
 
@@ -76,12 +75,12 @@ oneNotrumpAlt = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got at least mild slam interest with 12+ HCP, and a 5-card\
-      \ heart suit. Bid " ++ output fmt (T.Bid 1 T.Notrump) ++ " to show this.\
-      \ Partner's bids are natural: " ++ output fmt (T.Bid 2 T.Hearts) ++ " is\
-      \ a heart raise, other suits are 5 cards long, and " ++
-        output fmt (T.Bid 2 T.Notrump) ++ " shows a notrump response.\
+      \ heart suit. Bid " .+ T.Bid 1 T.Notrump .+ " to show this.\
+      \ Partner's bids are natural: " .+ T.Bid 2 T.Hearts .+ " is\
+      \ a heart raise, other suits are 5 cards long, and " .+
+        T.Bid 2 T.Notrump .+ " shows a notrump response.\
       \ Compared to the naive approach, this never wastes extra bidding room\
       \ and often saves some for control bids after we've found a fit."
   in
@@ -105,9 +104,9 @@ slamSingleSuitModified :: Situations
             b1C
             oppsPass
             mapM_ (`maxSuitLength` 4) . filter (/= strain) $ T.allSuits
-        explanation fmt =
+        explanation =
             "You've got at least mild slam interest with 12+ HCP, and a 5+ card\
-          \ suit. Bid a natural " ++ output fmt (T.Bid level strain) ++ ",\
+          \ suit. Bid a natural " .+ T.Bid level strain .+ ",\
           \ and we'll go from there. Subsequent bids are natural 5-card (and\
           \ later 4-card) suits, not MaFiA. Once we find a trump fit, we'll\
           \ start control bidding."
@@ -124,15 +123,15 @@ twoHeartsBalanced = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got decent slam interest with 14+ HCP, but a balanced\
-      \ hand with no 5-card suit. Bid " ++ output fmt (T.Bid 2 T.Hearts) ++ "\
-      \ to show this. Partner can try " ++ output fmt (T.Bid 2 T.Notrump) ++ "\
-      \ to show hearts, " ++ output fmt (T.Bid 3 T.Clubs) ++ " as Stayman\
+      \ hand with no 5-card suit. Bid " .+ T.Bid 2 T.Hearts .+ "\
+      \ to show this. Partner can try " .+ T.Bid 2 T.Notrump .+ "\
+      \ to show hearts, " .+ T.Bid 3 T.Clubs .+ " as Stayman\
       \ (regular-type! Puppet is not needed because you've already denied a\
       \ 5-card major), or otherwise bid naturally. If partner has clubs,\
-      \ they're likely to prefer notrump, but could also try a jump to " ++
-        output fmt (T.Bid 3 T.Spades) ++ " to show that (which should be\
+      \ they're likely to prefer notrump, but could also try a jump to " .+
+        T.Bid 3 T.Spades .+ " to show that (which should be\
       \ surprising enough for you to recognize/remember)."
   in
     smpWrapN . return $ situation "2HAlt" action B.b1C2Halt explanation
@@ -144,11 +143,11 @@ twoNotrumpBalanced = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
-        "You've got very mild slam interest with 12" ++ output fmt NDash ++
-        "13 HCP, but a balanced hand with no 5-card suit. Bid " ++
-        output fmt (T.Bid 2 T.Notrump) ++ " to show this. Partner can try " ++
-        output fmt (T.Bid 3 T.Clubs) ++ " as Stayman (regular-type! Puppet is\
+    explanation =
+        "You've got very mild slam interest with 12" .+ NDash .+
+        "13 HCP, but a balanced hand with no 5-card suit. Bid " .+
+        T.Bid 2 T.Notrump .+ " to show this. Partner can try " .+
+        T.Bid 3 T.Clubs .+ " as Stayman (regular-type! Puppet is\
       \ not needed because you've already denied a 5-card major), or otherwise\
       \ bid naturally. They're captain of the auction: they'll know whether to\
       \ sign off in game or investigate slam."
@@ -158,15 +157,15 @@ twoNotrumpBalanced = let
 
 oneSpadeGF :: Situations
 oneSpadeGF = let
-    explanationMin fmt =
+    explanationMin =
         "You've got game-forcing strength and a 5-card spade suit. Start with\
-      \ bidding " ++ output fmt (T.Bid 1 T.Spades) ++ " to describe this type\
+      \ bidding " .+ T.Bid 1 T.Spades .+ " to describe this type\
       \ of hand. Partner will bid naturally, and when we find a fit, you'll\
       \ sign off in game to show no interest in going further (though partner\
       \ can always push on if they've got a monster)."
-    explanationMax fmt =
+    explanationMax =
         "You've got a 5-card spade suit and at least mild slam interest. Start\
-      \ with " ++ output fmt (T.Bid 1 T.Spades) ++ " to show partner we'e at\
+      \ with " .+ T.Bid 1 T.Spades .+ " to show partner we'e at\
       \ least game forcing. When you find a fit, start control bidding to show\
       \ partner you're interested in slam, too."
     sit (explanation, minHcp, maxHcp) = let
@@ -186,15 +185,14 @@ twoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You've got at least mild slam interest with 12+ HCP, but an awkward\
-      \ triple-four-one shape. Show this by bidding " ++
-        output fmt (T.Bid 2 T.Spades) ++ ". Partner will relay to " ++
-        output fmt (T.Bid 2 T.Notrump) ++ ", then bid your singleton. Partner\
-      \ will then either bid " ++ output fmt (T.Bid 3 T.Notrump) ++ ",\
-      \ set trump at the 3 level (triggering a round of control bidding), or \
-      \ use " ++ output fmt (T.Bid 4 T.Clubs) ++ "/" ++
-        output fmt (T.Bid 4 T.Diamonds) ++ "/RKC to tell us how high to go and\
+      \ triple-four-one shape. Show this by bidding " .+
+        T.Bid 2 T.Spades .+ ". Partner will relay to " .+ T.Bid 2 T.Notrump .+
+       ", then bid your singleton. Partner will then either bid " .+
+        T.Bid 3 T.Notrump .+ ", set trump at the 3 level (triggering a round\
+      \ of control bidding), or  use " .+ T.Bid 4 T.Clubs .+ "/" .+
+        T.Bid 4 T.Diamonds .+ "/RKC to tell us how high to go and\
       \ what suit is trump."
   in
     smpWrapN . return $ situation "2S" action B.b1C2S explanation
@@ -221,10 +219,10 @@ passGameSingleSuit = let
             b1C
             oppsPass
             mapM_ (`maxSuitLength` 4) . filter (/= strain) $ T.allSuits
-        explanation fmt =
+        explanation =
             "You're game-forcing with a 5+ card suit. but you're a passed hand,\
           \ so all the slam bids have turned into game bids instead. Bid a\
-          \ natural " ++ output fmt (T.Bid level strain) ++ ",\
+          \ natural " .+ T.Bid level strain .+ ",\
           \ and we'll look for a trump fit from there. Partner's next bid is\
           \ a 5-card suit, and bids after that are 4+ cards."
       in
@@ -244,13 +242,12 @@ passOneNotrump = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You're a passed hand with game-forcing strength but no 5-card suit.\
       \ Because you're a passed hand, the slam-interest bids are repurposed to\
-      \ be merely game forcing. Bid a natural " ++
-        output fmt (T.Bid 1 T.Notrump) ++ ", and we'll\
-      \ go from there. Stayman is on, but transfers are off (so the stronger\
-      \ hand will be declarer more often)."
+      \ be merely game forcing. Bid a natural " .+ T.Bid 1 T.Notrump .+ ", and\
+      \ we'll go from there. Stayman is on, but transfers are off (so the\
+      \ stronger hand will be declarer more often)."
   in
     smpWrapS . return $ situation "P1N" action B.bP1C1N explanation
 
@@ -266,15 +263,15 @@ passTwoSpades = let
         firstSeatOpener
         b1C
         oppsPass
-    explanation fmt =
+    explanation =
         "You're a passed hand with game-forcing strength, but an awkward\
-      \ triple-four-one shape. Show this by bidding " ++
-        output fmt (T.Bid 2 T.Spades) ++ ". Partner will relay to " ++
-        output fmt (T.Bid 2 T.Notrump) ++ ", then bid your singleton. Partner\
-      \ will then either sign off in " ++ output fmt (T.Bid 3 T.Notrump) ++ ",\
+      \ triple-four-one shape. Show this by bidding " .+
+        T.Bid 2 T.Spades .+ ". Partner will relay to " .+
+        T.Bid 2 T.Notrump .+ ", then bid your singleton. Partner\
+      \ will then either sign off in " .+ T.Bid 3 T.Notrump .+ ",\
       \ set trump at the 3 level (triggering a round of control bidding), or \
-      \ use " ++ output fmt (T.Bid 4 T.Clubs) ++ "/" ++
-        output fmt (T.Bid 4 T.Diamonds) ++ "/RKC to indicate how high to go\
+      \ use " .+ T.Bid 4 T.Clubs .+ "/" .+
+        T.Bid 4 T.Diamonds .+ "/RKC to indicate how high to go\
       \ and which suit is trump."
   in
     smpWrapS . return $ situation "P2S" action B.bP1C2S explanation

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
-import Output(output, Punct(..))
+import Output(output, Punct(..), (.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(maxSuitLength, minSuitLength, pointRange, displayLastCall,
                alternatives)
@@ -16,8 +16,8 @@ oneMajor = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
-            "Let's start with a natural " ++ displayLastCall fmt bid ++ "\
+        explanation =
+            "Let's start with a natural " .+ displayLastCall bid .+ "\
            \ bid, and see where things go from there."
       in
         situation "1M" action bid explanation
@@ -97,14 +97,14 @@ reverseFlannery = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
-            "With 5 spades, 4 or 5 hearts, and " ++
-            (if isInvite then "" else "less than ") ++
-            "invitational strength, bid a Reverse Flannery " ++
-            displayLastCall fmt bid ++ ". Partner can then place the final\
-          \ contract, bid " ++ output fmt (T.Bid 3 T.Clubs) ++ " (pass or\
-          \ correct) with both minors, or bid " ++
-            output fmt (T.Bid 2 T.Notrump) ++ " to ask for\
+        explanation =
+            "With 5 spades, 4 or 5 hearts, and " .+
+            (if isInvite then "" else "less than ") .+
+            "invitational strength, bid a Reverse Flannery " .+
+            displayLastCall bid .+ ". Partner can then place the final\
+          \ contract, bid " .+ T.Bid 3 T.Clubs .+ " (pass or\
+          \ correct) with both minors, or bid " .+
+            T.Bid 2 T.Notrump .+ " to ask for\
           \ more information. Note that if you were game forcing, you would\
           \ have started at the 1 level instead."
       in
@@ -220,9 +220,9 @@ invertedMinors = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
+        explanation =
             "With less than invitational strength, no 4-card major, but a long\
-           \ diamond suit, jump to " ++ displayLastCall fmt B.b1D3D ++ ", like\
+           \ diamond suit, jump to " .+ displayLastCall B.b1D3D .+ ", like\
            \ an inverted minor. Note that you need 6+ cards in the suit to do\
            \ this, since opener might only have a doubleton."
       in

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
-import Output(output, Punct(..), (.+))
+import Output(Punct(..), (.+))
 import Topic(Topic(..), wrap, Situations)
 import Auction(maxSuitLength, minSuitLength, pointRange, displayLastCall,
                alternatives)
@@ -78,10 +78,10 @@ twoMinorBothInv = let
             maxSuitLength T.Hearts 3
             maxSuitLength T.Spades 3
             pointRange 11 13
-        explanation fmt =
-            "With invitational strength and both minors, start with " ++
-            output fmt (T.Bid 2 T.Diamonds) ++ ", planning to rebid " ++
-            output fmt (T.Bid 3 T.Clubs) ++ " to give partner a choice of\
+        explanation =
+            "With invitational strength and both minors, start with " .+
+            T.Bid 2 T.Diamonds .+ ", planning to rebid " .+
+            T.Bid 3 T.Clubs .+ " to give partner a choice of\
            \ minors. Be prepared to go to game if partner shows a maximum, but\
            \ they're more likely to have a minimum which will pass or correct\
            \ at the 3 level."
@@ -119,10 +119,10 @@ weakMinors54 = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
+        explanation =
             "With 5-4 in the minors, no 4-card major, and less than\
-           \ invitational strength, bid a pre-emptive-like " ++
-             output fmt (T.Bid 3 T.Clubs) ++ ". Partner can pass or correct, or\
+           \ invitational strength, bid a pre-emptive-like " .+
+             T.Bid 3 T.Clubs .+ ". Partner can pass or correct, or\
            \ even continue the pre-empt if relevant. We might get unlucky and\
            \ end up in a 7-card fit, but most of the time we'll have a decent\
            \ fit in opener's favorite minor."
@@ -138,10 +138,9 @@ weakMinors55 = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
+        explanation =
             "With at least 5-5 in the minors and less than invitational\
-           \ strength,\
-           \ bid a pre-emptive-like " ++ output fmt (T.Bid 4 T.Clubs) ++ ".\
+           \ strength, bid a pre-emptive-like " .+ T.Bid 4 T.Clubs .+ ".\
            \ Partner can pass or correct, or even continue the pre-empt if\
            \ relevant. We're guaranteed at least an 8-card fit in opener's\
            \ favorite minor."
@@ -157,9 +156,9 @@ notrump1 = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
+        explanation =
             "With a balanced hand, no 4-card major, and less than invitational\
-           \ strength, bid " ++ output fmt (T.Bid 1 T.Notrump) ++ ". Partner\
+           \ strength, bid " .+ T.Bid 1 T.Notrump .+ ". Partner\
            \ will likely pass, but could bid 2 of a major with 6-5 and a\
            \ maximum, which you can pass or correct."
       in
@@ -174,17 +173,17 @@ notrump2 = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
-            "With a balanced hand, no 4-card major, and 11" ++
-             output fmt NDash ++ "12 HCP, bid " ++
-             output fmt (T.Bid 2 T.Notrump) ++ ". Note that 13 HCP hands should\
+        explanation =
+            "With a balanced hand, no 4-card major, and 11" .+
+             NDash .+ "12 HCP, bid " .+
+             T.Bid 2 T.Notrump .+ ". Note that 13 HCP hands should\
            \ bid game even though they're usually considered invitational!\
-           \ Partner can pass, bid " ++ output fmt (T.Bid 3 T.Clubs) ++ "\
+           \ Partner can pass, bid " .+ T.Bid 3 T.Clubs .+ "\
            \ (pass or correct) with both minors and a minimum (with a maximum,\
-           \ prefer playing in " ++ output fmt (T.Bid 2 T.Notrump) ++ "), " ++
-             output fmt (T.Bid 3 T.Diamonds) ++ " with a long suit and minimum\
+           \ prefer playing in " .+ T.Bid 2 T.Notrump .+ "), " .+
+             T.Bid 3 T.Diamonds .+ " with a long suit and minimum\
            \ strength, 3 of a major with 4 cards in that major and shortness in\
-           \ the other one (angling for " ++ output fmt (T.Bid 3 T.Notrump) ++
+           \ the other one (angling for " .+ T.Bid 3 T.Notrump .+
             " or 4 of a minor if you don't have a stopper in the other major),\
            \ or 4 of a major with 6-5 and a maximum, which you can pass or\
            \ correct."
@@ -200,14 +199,12 @@ notrump3 = let
         action = do
             b1D
             oppsPass
-        explanation fmt =
-            "With a balanced hand, no 4-card major, and 13" ++
-            output fmt NDash ++ "16 HCP, bid " ++
-            output fmt (T.Bid 3 T.Notrump) ++ ". Partner\
+        explanation =
+            "With a balanced hand, no 4-card major, and 13" .+ NDash .+ "16\
+           \ HCP, bid " .+ T.Bid 3 T.Notrump .+ ". Partner\
            \ will likely pass, but could bid game in a major with 6-5 shape,\
-           \ which you can pass or correct to " ++
-             output fmt (T.Bid 4 T.Notrump) ++ " or " ++
-             output fmt (T.Bid 5 T.Diamonds) ++ "."
+           \ which you can pass or correct to " .+
+             T.Bid 4 T.Notrump .+ " or " .+ T.Bid 5 T.Diamonds .+ "."
       in
         situation "3N" action B.b1D3N explanation
   in

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -35,7 +35,7 @@ twoMinor6M = let
             minSuitLength major 4
             maxSuitLength major 5
             pointRange 14 40
-        explanation _ =
+        explanation =
             "With game-forcing strength, a 4- or 5-card major, but a 6+ card\
            \ minor, start by bidding 2 of the minor. There will be time to\
            \ show the major afterward."
@@ -56,7 +56,7 @@ twoMinorLongInv = let
             maxSuitLength T.Hearts 3
             maxSuitLength T.Spades 3
             pointRange 11 13
-        explanation _ =
+        explanation =
             "With invitational strength and a 6-card minor, bid naturally,\
            \ planning to rebid your suit at the 3 level if partner doesn't\
            \ show a maximum hand."
@@ -237,7 +237,7 @@ preempt3M = let
         action = do
             b1D
             oppsPass
-        explanation _ =
+        explanation =
             "With a weak hand and a 7-card major, jump to 3 of that suit.\
            \ Opener should pretend that you opened with a pre-empt: they will\
            \ likely pass, even if we don't have a great fit, but can continue\
@@ -257,7 +257,7 @@ preempt4D = let
         action = do
             b1D
             oppsPass
-        explanation _ =
+        explanation =
             "With a weak hand and 8-card support for partner's diamonds, jump\
            \ to 4 of that suit. Opener has at least a doubleton, so on the LoTT\
            \ you're probably safe to the 4 level."
@@ -276,7 +276,7 @@ majorGame = let
         action = do
             b1D
             oppsPass
-        explanation _ =
+        explanation =
             "With an 8-card major, jump to game. This bid has a very wide\
            \ point range, which makes it difficult for the opponents because\
            \ maybe you're pre-empting and maybe you're game forcing with no\

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.OpeningBids(topic) where
 
-import Output(output)
+import Output((.+))
 import Topic(Topic(..), wrap, Situations)
 import Situation(situation, (<~))
 import qualified Terminology as T
@@ -11,9 +11,9 @@ oneClub :: Situations
 oneClub = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
-        "With 16 or more points (17 or more when balanced), open a strong " ++
-        output fmt (T.Bid 1 T.Clubs) ++ ". This is the hallmark of SMP."
+    explanation =
+        "With 16 or more points (17 or more when balanced), open a strong " .+
+        T.Bid 1 T.Clubs .+ ". This is the hallmark of SMP."
   in
     B.smpWrapS . return $ situation "1C" action B.b1C explanation
 
@@ -22,9 +22,9 @@ oneDiamond :: Situations
 oneDiamond = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
+    explanation =
         "With opening strength but the wrong strength/shape for any other\
-      \ opening bid, start with " ++ output fmt (T.Bid 1 T.Diamonds) ++ "."
+      \ opening bid, start with " .+ T.Bid 1 T.Diamonds .+ "."
   in
     B.smpWrapS . return $ situation "1D" action B.b1D explanation
 
@@ -35,10 +35,10 @@ oneMajor = let
         action = do
             B.firstSeatOpener
             -- TODO: What if you're 5-5?
-        explanation fmt =
-            "With opening strength but not enough for a strong " ++
-            output fmt (T.Bid 1 T.Clubs) ++ " or " ++
-            output fmt (T.Bid 1 T.Notrump) ++ ", open a 5-card major suit."
+        explanation =
+            "With opening strength but not enough for a strong " .+
+            T.Bid 1 T.Clubs .+ " or " .+ T.Bid 1 T.Notrump .+ ", open a 5-card\
+          \ major suit."
       in
         situation "1M" action (B.b1M suit) explanation
   in
@@ -50,9 +50,8 @@ oneNotrump :: Situations
 oneNotrump = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
-        "With a balanced hand and 14-16 HCP, open " ++
-        output fmt (T.Bid 1 T.Notrump) ++ "."
+    explanation =
+        "With a balanced hand and 14-16 HCP, open " .+ T.Bid 1 T.Notrump .+ "."
   in
     B.smpWrapS . return $ situation "1N" action B.b1N explanation
 
@@ -61,10 +60,10 @@ twoClubs :: Situations
 twoClubs = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
+    explanation =
         "With a 6-card club suit, no 5-card major, an opening hand but not a\
-       \ hand strong enough to open " ++ output fmt (T.Bid 1 T.Clubs) ++ ",\
-       \ open " ++ output fmt (T.Bid 2 T.Clubs) ++ "."
+       \ hand strong enough to open " .+ T.Bid 1 T.Clubs .+ ",\
+       \ open " .+ T.Bid 2 T.Clubs .+ "."
   in
     B.smpWrapS . return $ situation "2C" action B.b2C explanation
 
@@ -73,8 +72,8 @@ twoDiamonds :: Situations
 twoDiamonds = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
-        "The " ++ output fmt (T.Bid 2 T.Diamonds) ++ " hand is that 3-suited\
+    explanation =
+        "The " .+ T.Bid 2 T.Diamonds .+ " hand is that 3-suited\
        \ hand without diamonds, which can be thought of as a 14-card hand with\
        \ 4415 shape but missing any single card."
   in
@@ -85,9 +84,9 @@ twoNotrump :: Situations
 twoNotrump = let
     action = do
         B.firstSeatOpener
-    explanation fmt =
-        "With a balanced hand and 19 to a bad 21 HCP, open " ++
-        output fmt (T.Bid 2 T.Notrump) ++ "."
+    explanation =
+        "With a balanced hand and 19 to a bad 21 HCP, open " .+
+        T.Bid 2 T.Notrump .+ "."
   in
     B.smpWrapS . return $ situation "2N" action B.b2N explanation
 

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -1,6 +1,6 @@
 module Topics.StandardModernPrecision.TwoDiamondOpeners(topic) where
 
-import Output(output)
+import Output((.+))
 import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
 import Auction(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
                Action, alternatives, constrain, makePass, makeCall,
@@ -61,10 +61,9 @@ open :: Situations
 open = let
     action = do
         B.setOpener T.South
-    explanation fmt =
-        "With an opening hand too weak to bid " ++
-        output fmt (T.Bid 1 T.Clubs) ++ ", open " ++
-        output fmt (T.Bid 2 T.Diamonds) ++ " with no 5-card major, " ++
+    explanation =
+        "With an opening hand too weak to bid " .+ T.Bid 1 T.Clubs .+ ", " .+
+        "open " .+ T.Bid 2 T.Diamonds .+ " with no 5-card major, " .+
         "no 6-card club suit, and at most 1 diamond."
   in
     stdWrap $ situation "Open" action twoDiamondOpener explanation
@@ -80,10 +79,10 @@ immediateSignoffSpades3 = let
         pointRange 0 9
         bestFitSpades
         suitLength T.Spades 4
-    explanation fmt =
-        "Without the strength for a game contract, sign off in " ++
-        output fmt (T.Bid 2 T.Spades) ++ " with a likely fit. If " ++
-        "you're stuck playing a 4-3 fit, oh well."
+    explanation =
+        "Without the strength for a game contract, sign off in " .+
+        T.Bid 2 T.Spades .+ " with a likely fit. If you're stuck playing a " .+
+        "4-3 fit, oh well."
   in
     stdWrap $ situation "S43" action (makeCall $ T.Bid 2 T.Spades) explanation
 
@@ -98,9 +97,9 @@ immediateSignoffSpades4 = let
         pointRange 0 9
         bestFitSpades
         suitLength T.Spades 4
-    explanation fmt =
-        "Without the strength for a game contract, sign off in " ++
-        output fmt (T.Bid 2 T.Spades) ++ " with a likely fit."
+    explanation =
+        "Without the strength for a game contract, sign off in " .+
+        T.Bid 2 T.Spades .+ " with a likely fit."
   in
     stdWrap $ situation "S44" action (makeCall $ T.Bid 2 T.Spades) explanation
 
@@ -115,9 +114,9 @@ immediateSignoffSpades5 = let
             pointRange 0 6  -- With 7-9 HCP, make a mixed raise!
             bestFitSpades
             minSuitLength T.Spades 5
-        explanation fmt =
-            "Without the strength for a game contract, sign off in " ++
-            output fmt (T.Bid 2 T.Spades) ++ " with a guaranteed fit."
+        explanation =
+            "Without the strength for a game contract, sign off in " .+
+            T.Bid 2 T.Spades .+ " with a guaranteed fit."
       in
         situation "Sfit" action (makeCall $ T.Bid 2 T.Spades) explanation
   in
@@ -144,8 +143,8 @@ passSignoff2Spades = let
             noDirectOvercall
             suitLength T.Spades spadeLength
         explanation =
-            "Partner has less-than-invitational values and is signing off. " ++
-            "Just pass" ++
+            "Partner has less-than-invitational values and is signing off. " .+
+            "Just pass" .+
             (if spadeLength == 4 then "." else
                 ", even though you might be in a 7-card fit.")
       in
@@ -163,7 +162,7 @@ immediateSignoffClubs = let
         bestFitClubs
         pointRange 0 9
     explanation =
-        "Without the strength to invite to game, sign off in a club " ++
+        "Without the strength to invite to game, sign off in a club " .+
         "partial."
   in
     stdWrap $ situation "3C" action (makeCall $ T.Bid 3 T.Clubs) explanation
@@ -181,7 +180,7 @@ passSignoffClubs = let
         forbid $ B.takeoutDouble T.Clubs
         noDirectOvercall
     explanation =
-        "Partner has less-than-invitational values and is signing off. " ++
+        "Partner has less-than-invitational values and is signing off. " .+
         "Just pass."
   in
     stdWrap $ situation "3CP" action (makeCall T.Pass) explanation
@@ -195,10 +194,10 @@ immediateSignoffHearts = let
         noDirectOvercall
         fitHearts
         pointRange 0 9
-    explanation fmt =
-        "Without the strength to invite to game, sign off in " ++
-        output fmt (T.Bid 2 T.Hearts) ++ ". Remember that opener might " ++
-        "pull the bid to " ++ output fmt (T.Bid 2 T.Spades) ++ " with " ++
+    explanation =
+        "Without the strength to invite to game, sign off in " .+
+        T.Bid 2 T.Hearts .+ ". Remember that opener might " .+
+        "pull the bid to " .+ T.Bid 2 T.Spades .+ " with " .+
         "exactly 4315 shape."
   in
     stdWrap $ situation "2H" action (makeCall $ T.Bid 2 T.Hearts) explanation
@@ -217,7 +216,7 @@ passSignoffHearts = let
         noDirectOvercall
         minSuitLength T.Hearts 4
     explanation =
-        "Partner has less-than-invitational values and is signing off. " ++
+        "Partner has less-than-invitational values and is signing off. " .+
         "Given that you have 4 hearts, pass."
   in
     stdWrap $ situation "2HP" action (makeCall T.Pass) explanation
@@ -239,10 +238,10 @@ correctSignoffHearts = let
             forbid $ B.takeoutDouble T.Clubs
             noDirectOvercall
             maxSuitLength T.Hearts 3
-        explanation fmt =
-            "Partner has less-than-invitational values and is signing off. " ++
-            "With 4315 shape, though, pull this to " ++
-            output fmt (T.Bid 2 T.Spades) ++ " in case partner only had 3 " ++
+        explanation =
+            "Partner has less-than-invitational values and is signing off. " .+
+            "With 4315 shape, though, pull this to " .+
+            T.Bid 2 T.Spades .+ " in case partner only had 3 " .+
             "hearts (e.g., 3343 or 3352 shape)."
       in
         situation "2H2S" action (makeCall $ T.Bid 2 T.Spades) explanation

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -143,7 +143,7 @@ passSignoff2Spades = let
             forbid $ B.takeoutDouble T.Spades
             noDirectOvercall
             suitLength T.Spades spadeLength
-        explanation _ =
+        explanation =
             "Partner has less-than-invitational values and is signing off. " ++
             "Just pass" ++
             (if spadeLength == 4 then "." else
@@ -162,7 +162,7 @@ immediateSignoffClubs = let
         noDirectOvercall
         bestFitClubs
         pointRange 0 9
-    explanation _ =
+    explanation =
         "Without the strength to invite to game, sign off in a club " ++
         "partial."
   in
@@ -180,7 +180,7 @@ passSignoffClubs = let
         makeAlertableCall (T.Bid 3 T.Clubs) "signoff"
         forbid $ B.takeoutDouble T.Clubs
         noDirectOvercall
-    explanation _ =
+    explanation =
         "Partner has less-than-invitational values and is signing off. " ++
         "Just pass."
   in
@@ -216,7 +216,7 @@ passSignoffHearts = let
         forbid $ B.takeoutDouble T.Clubs
         noDirectOvercall
         minSuitLength T.Hearts 4
-    explanation _ =
+    explanation =
         "Partner has less-than-invitational values and is signing off. " ++
         "Given that you have 4 hearts, pass."
   in

--- a/src/Topics/StandardOpeners.hs
+++ b/src/Topics/StandardOpeners.hs
@@ -1,6 +1,6 @@
 module Topics.StandardOpeners(topic) where
 
-import Output(output)
+import Output((.+))
 import Topic(Topic(..), wrap, stdWrap, wrapVulDlr, Situations)
 import Auction(forbid, suitLength, minSuitLength, maxSuitLength)
 import Situation(situation, (<~))
@@ -18,9 +18,9 @@ oneNotrump :: Situations
 oneNotrump = let
     action = do
         B.setOpener T.South
-    explanation fmt =
-        "With 15 to 17 HCP and a balanced hand, open a strong " ++
-        output fmt (T.Bid 1 T.Notrump) ++ ". No need to plan a second bid;\
+    explanation =
+        "With 15 to 17 HCP and a balanced hand, open a strong " .+
+        T.Bid 1 T.Notrump .+ ". No need to plan a second bid;\
       \ partner is now captain of the auction and will take over for you."
   in
     stdWrap $ situation "1N" action SO.b1n explanation
@@ -30,9 +30,9 @@ twoNotrump :: Situations
 twoNotrump = let
     action = do
         B.setOpener T.South
-    explanation fmt =
-        "With 20 to 21 HCP and a balanced hand, open " ++
-        output fmt (T.Bid 2 T.Notrump) ++ ". No need to plan a second bid;\
+    explanation =
+        "With 20 to 21 HCP and a balanced hand, open " .+
+        T.Bid 2 T.Notrump .+ ". No need to plan a second bid;\
       \ partner is now captain of the auction and will take over for you."
   in
     stdWrap $ situation "2N" action SO.b2n explanation
@@ -43,9 +43,9 @@ oneSpade = let
     action = do
         B.setOpener T.South
         forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-    explanation fmt =
+    explanation =
         "With a 5-card spade suit and a hand unsuitable for opening \
-      \ notrump, open " ++ output fmt (T.Bid 1 T.Spades) ++ "."
+      \ notrump, open " .+ T.Bid 1 T.Spades .+ "."
   in
     stdWrap $ situation "1S" action SO.b1s explanation
 
@@ -55,9 +55,9 @@ oneHeart = let
     action = do
         B.setOpener T.South
         forbid $ minSuitLength T.Spades 5 >> minSuitLength T.Hearts 5
-    explanation fmt =
+    explanation =
         "With a 5-card heart suit and a hand unsuitable for opening \
-      \ notrump, open " ++ output fmt (T.Bid 1 T.Hearts) ++ "."
+      \ notrump, open " .+ T.Bid 1 T.Hearts .+ "."
   in
     stdWrap $ situation "1H" action SO.b1h explanation
 
@@ -68,10 +68,10 @@ bothMajorsReverse = let
         B.setOpener T.South
         minSuitLength T.Spades 5
         minSuitLength T.Hearts 5
-    explanation fmt =
+    explanation =
         "With at least 5-5 in the majors and enough strength to reverse,\
-      \ open " ++ output fmt (T.Bid 1 T.Hearts) ++ ", planning to rebid " ++
-        output fmt (T.Bid 2 T.Spades) ++ " next turn."
+      \ open " .+ T.Bid 1 T.Hearts .+ ", planning to rebid " .+
+        T.Bid 2 T.Spades .+ " next turn."
   in
     stdWrap $ situation "MajRev" action SO.b1h explanation
 
@@ -82,10 +82,10 @@ bothMajorsNoReverse = let
         B.setOpener T.South
         minSuitLength T.Spades 5
         minSuitLength T.Hearts 5
-    explanation fmt =
+    explanation =
         "With at least 5-5 in the majors and not enough strength to\
-      \ reverse, open " ++ output fmt (T.Bid 1 T.Spades) ++ ", planning\
-      \ to rebid " ++ output fmt (T.Bid 2 T.Hearts) ++ " next turn."
+      \ reverse, open " .+ T.Bid 1 T.Spades .+ ", planning to rebid " .+
+        T.Bid 2 T.Hearts .+ " next turn."
   in
     stdWrap $ situation "MajNoRev" action SO.b1s explanation
 
@@ -96,9 +96,9 @@ oneDiamond = let
         B.setOpener T.South
         maxSuitLength T.Clubs 3
         minSuitLength T.Diamonds 4
-    explanation fmt =
+    explanation =
         "With no 5-card major and a hand unsuitable for opening \
-      \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
+      \ notrump, open " .+ T.Bid 1 T.Diamonds .+ " when \
       \ diamonds is your only minor."
   in
     stdWrap $ situation "1D1Suit" action SO.b1d explanation
@@ -112,9 +112,9 @@ oneDiamond3Cards = let
         suitLength T.Hearts   4
         suitLength T.Diamonds 3
         suitLength T.Clubs    2
-    explanation fmt =
+    explanation =
         "With no 5-card major and a hand unsuitable for opening \
-      \ notrump, open " ++ output fmt (T.Bid 1 T.Diamonds) ++ " when \
+      \ notrump, open " .+ T.Bid 1 T.Diamonds .+ " when \
       \ diamonds is your only minor, even if you only have 3 of them. The \
       \ only time you'd open 1D with a 3-card suit in standard openings is \
       \ when your shape is exactly 4=4=3=2."
@@ -128,10 +128,9 @@ oneClub = let
         B.setOpener T.South
         maxSuitLength T.Diamonds 3
         minSuitLength T.Clubs 4
-    explanation fmt =
-        "With no 5-card major and a hand unsuitable for opening \
-      \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
-      \ clubs is your only minor."
+    explanation =
+        "With no 5-card major and a hand unsuitable for opening  notrump,\
+      \ open " .+ T.Bid 1 T.Clubs .+ " when  clubs is your only minor."
   in
     stdWrap $ situation "1C1Suit" action SO.b1c explanation
 
@@ -143,9 +142,9 @@ oneClubEqualMinors = let
             B.setOpener T.South
             suitLength T.Diamonds len
             suitLength T.Clubs len
-        explanation fmt =
+        explanation =
             "With no 5-card major and a hand unsuitable for opening \
-          \ notrump, open " ++ output fmt (T.Bid 1 T.Clubs) ++ " when \
+          \ notrump, open " .+ T.Bid 1 T.Clubs .+ " when \
           \ your minors are of equal, short length. As the saying goes, \
           \ ``up the line with 3s and 4s, from the top with 5s or mores.''"
       in
@@ -160,10 +159,10 @@ bothMinorsNoReverse = let
         B.setOpener T.South
         minSuitLength T.Diamonds 5
         minSuitLength T.Clubs 5
-    explanation fmt =
-        "With both minors but not enough strength to reverse, open, " ++
-        output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
-        output fmt (T.Bid 2 T.Clubs) ++ " next turn."
+    explanation =
+        "With both minors but not enough strength to reverse, open, " .+
+        T.Bid 1 T.Diamonds .+ ", planning to rebid " .+
+        T.Bid 2 T.Clubs .+ " next turn."
   in
     stdWrap $ situation "MinNoRev" action SO.b1d explanation
 
@@ -174,10 +173,10 @@ bothMinorsNoReverseShortD = let
         B.setOpener T.South
         suitLength T.Diamonds 4
         suitLength T.Clubs 5
-    explanation fmt =
-        "With both minors but not enough strength to reverse, open " ++
-        output fmt (T.Bid 1 T.Diamonds) ++ ", planning to rebid " ++
-        output fmt (T.Bid 2 T.Clubs) ++ " next turn. This is even the case\
+    explanation =
+        "With both minors but not enough strength to reverse, open " .+
+        T.Bid 1 T.Diamonds .+ ", planning to rebid " .+
+        T.Bid 2 T.Clubs .+ " next turn. This is even the case\
       \ when your clubs are longer than your diamonds! Bidding clubs first\
       \ and diamonds second is a reverse (responder can't go back to your\
       \ first suit without going to the 3 level), and cannot be bid without\
@@ -193,10 +192,10 @@ bothMinorsReverse = let
         B.setOpener T.South
         minSuitLength T.Diamonds 5
         minSuitLength T.Clubs 5
-    explanation fmt =
-        "With both minors and enough strength to reverse, open, " ++
-        output fmt (T.Bid 1 T.Clubs) ++ ", planning to rebid " ++
-        output fmt (T.Bid 2 T.Diamonds) ++ " next turn."
+    explanation =
+        "With both minors and enough strength to reverse, open, " .+
+        T.Bid 1 T.Clubs .+ ", planning to rebid " .+
+        T.Bid 2 T.Diamonds .+ " next turn."
   in
     stdWrap $ situation "MinRev55" action SO.b1c explanation
 


### PR DESCRIPTION
I'm so pleased with the insight behind this! So much less boilerplate now. When writing commentary, instead of having a function that takes an `OutputType` and formatting each piece of the output right there, you just concatenate them all with `(.+)`, even if they naively appear to be different types, and they get formatted to whatever the output is supposed to be later! The `Commentary` type has been changed from an alias for `OutputType -> String` to its own struct containing a list of those functions (hence how the concatenation works).

The major change is in Output.hs, a handful of other files in that directory changed to match, and then all the changes within the Topics directory are just simplifying the formatting. and the next format simplification after this one is going to be that you can put in the `Action`s being discussed instead of writing out their bids all over again. (Not sure if that next one is a good idea: it makes it too easy to have mistakes due to copying and pasting things without updating them. but it's at least possible if you want it.)

The vestigial parts of Output.hs, including `Outputtable` and `Wrap` have also been removed as no longer necessary. 

Because this is such a big change, I should probably review it carefully before merging. My hope is that going commit-by-commit is easy.