### PR TITLE
Remove some of the LaTeX warnings

### DIFF
--- a/bridge.tex
+++ b/bridge.tex
@@ -21,7 +21,7 @@
 \newcommand{\hand}[4]{{%
   %Example: \hand{AKJ765}{AK9}{--}{T983}
   \setlength{\tabcolsep}{0.5ex}
-  \begin{tabular}[t]{|r|l|}
+  \begin{tabular}[t]{rl}
     \s&#1\\
     \h&#2\\
     \d&#3\\
@@ -32,7 +32,7 @@
 \newcommand{\NESW}{{
   \setlength{\tabcolsep}{0mm}
   \begin{centering}
-  \begin{tabular}[t]{|c|c|c|}
+  \begin{tabular}[t]{|ccc|}
     \hline
     &N&\\
     ~W&&E~{}~\\
@@ -56,7 +56,7 @@
 
 \newcommand{\fulldeal}[6]{
   % Arguments are: dealer, vulnerability, N E S W
-  \begin{tabular}[t]{|l|l|l|}
+  \begin{tabular}[t]{lll}
     \stepcounter{dealno}
     \textbf{Deal \arabic{dealno}}&#3&
     \begin{tabular}[t]{l}Dlr: #1\\ Vul: #2\end{tabular}\\
@@ -68,7 +68,7 @@
 \newcommand{\isolatedhand}[6]{
   % Arguments are: dealer, vulnerability, N E S W
   % We only want to show dealer, vulnerability, and the South hand
-  \begin{tabular}{|l|l|l|}
+  \begin{tabular}{lll}
     \stepcounter{dealno}
     \textbf{Deal \arabic{dealno}}&
     \begin{tabular}[t]{l}
@@ -88,7 +88,7 @@
 
 \newenvironment{bidding}{
   \begin{minipage}[t]{2in}
-    \begin{tabular}{|l|l|l|l|}%
+    \begin{tabular}{llll}%
       \emph{West}&
       \emph{North}&
       \emph{East}&
@@ -126,8 +126,7 @@
 
     ~ % Note that using \\ in a minipage gives "underful hbox" errors.
 
-    {\footnotesize Debug Ref.: #5
-      }
+    {\footnotesize Debug Ref.: #5}
   \end{minipage}
   \vspace*{0.5ex}\\
 }
@@ -143,7 +142,7 @@
 
 \newenvironment{problemset}{
   \begin{center}
-    \begin{longtable}[H]{|l|l|}
+    \begin{longtable}[H]{ll}
 }{
       \hline
     \end{longtable}

--- a/bridge.tex
+++ b/bridge.tex
@@ -21,7 +21,7 @@
 \newcommand{\hand}[4]{{%
   %Example: \hand{AKJ765}{AK9}{--}{T983}
   \setlength{\tabcolsep}{0.5ex}
-  \begin{tabular}[t]{rl}
+  \begin{tabular}[t]{|r|l|}
     \s&#1\\
     \h&#2\\
     \d&#3\\
@@ -32,7 +32,7 @@
 \newcommand{\NESW}{{
   \setlength{\tabcolsep}{0mm}
   \begin{centering}
-  \begin{tabular}[t]{|ccc|}
+  \begin{tabular}[t]{|c|c|c|}
     \hline
     &N&\\
     ~W&&E~{}~\\
@@ -56,7 +56,7 @@
 
 \newcommand{\fulldeal}[6]{
   % Arguments are: dealer, vulnerability, N E S W
-  \begin{tabular}[t]{lll}
+  \begin{tabular}[t]{|l|l|l|}
     \stepcounter{dealno}
     \textbf{Deal \arabic{dealno}}&#3&
     \begin{tabular}[t]{l}Dlr: #1\\ Vul: #2\end{tabular}\\
@@ -68,7 +68,7 @@
 \newcommand{\isolatedhand}[6]{
   % Arguments are: dealer, vulnerability, N E S W
   % We only want to show dealer, vulnerability, and the South hand
-  \begin{tabular}{lll}
+  \begin{tabular}{|l|l|l|}
     \stepcounter{dealno}
     \textbf{Deal \arabic{dealno}}&
     \begin{tabular}[t]{l}
@@ -87,8 +87,8 @@
 }
 
 \newenvironment{bidding}{
-  \begin{minipage}[t]{1.9in}
-    \begin{tabular}{llll}%
+  \begin{minipage}[t]{2in}
+    \begin{tabular}{|l|l|l|l|}%
       \emph{West}&
       \emph{North}&
       \emph{East}&
@@ -117,12 +117,17 @@
     #1\\\\#2
   \end{tabular}
   &
-  \begin{minipage}[t]{3in}
-    Answer: #3\\ % Extra separation between the short answer and the explanation
+  \begin{minipage}[t]{2.58in}
+    Answer: #3
 
-    #4\\ % TODO: Maybe just change the paragraph separation length?
+    ~ % Extra spearation between the short answer and the explanation.
 
-    {\footnotesize Debug Ref.: #5}
+    #4 % TODO: Maybe just change the paragraph separation length?
+
+    ~ % Note that using \\ in a minipage gives "underful hbox" errors.
+
+    {\footnotesize Debug Ref.: #5
+      }
   \end{minipage}
   \vspace*{0.5ex}\\
 }
@@ -138,7 +143,7 @@
 
 \newenvironment{problemset}{
   \begin{center}
-    \begin{longtable}[H]{ll}
+    \begin{longtable}[H]{|l|l|}
 }{
       \hline
     \end{longtable}

--- a/run.sh
+++ b/run.sh
@@ -21,11 +21,14 @@ pushd /tmp > /dev/null
 
 echo ""
 echo "Generating PDFs..."
+# We rerun LaTeX twice each time, because the table widths might have changed.
+# It would be great to suppress all output from the first run, but if something
+# in it fails and it drops you into interactive mode, you need to see that!
 xelatex test.tex
-xelatex test.tex  # Rerun because table widths have been recalculated
+xelatex test.tex
 mv test.pdf questions.pdf
 xelatex "\let\showsolutions\relax\input{test}"
-xelatex "\let\showsolutions\relax\input{test}"  # More table width recalculation
+xelatex "\let\showsolutions\relax\input{test}"
 mv test.pdf solutions.pdf
 
 # Different OSes have different PDF viewers.

--- a/run.sh
+++ b/run.sh
@@ -22,8 +22,10 @@ pushd /tmp > /dev/null
 echo ""
 echo "Generating PDFs..."
 xelatex test.tex
+xelatex test.tex  # Rerun because table widths have been recalculated
 mv test.pdf questions.pdf
 xelatex "\let\showsolutions\relax\input{test}"
+xelatex "\let\showsolutions\relax\input{test}"  # More table width recalculation
 mv test.pdf solutions.pdf
 
 # Different OSes have different PDF viewers.

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -15,8 +15,9 @@ import SituationInstance(instantiate, SituationInstance)
 import Topic(Topic, topicName, refName, choose)
 
 
+-- TODO: find a more compact way to `show g`.
 reference :: String -> String -> StdGen -> String
-reference topic sit g = topic ++ "." ++ sit ++ " " ++ show g
+reference topic sit _ = topic ++ "." ++ sit ++ " "-- ++ show g
 
 
 generate :: Int -> [Topic] -> StdGen -> IO [SituationInstance]

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -17,7 +17,7 @@ import Topic(Topic, topicName, refName, choose)
 
 -- TODO: find a more compact way to `show g`.
 reference :: String -> String -> StdGen -> String
-reference topic sit _ = topic ++ "." ++ sit ++ " "-- ++ show g
+reference topic sit _ = topic ++ "." ++ sit ++ " TODO"-- ++ show g
 
 
 generate :: Int -> [Topic] -> StdGen -> IO [SituationInstance]


### PR DESCRIPTION
I totally forgot about this branch, but it should be merged in eventually. The PRNG representation was trying to print 64-bit numbers, which did not fit well in the narrow margins of the LaTeX document. "Fortunately," they weren't really being used for anything anyway. but they should be added back in with a more compact format, perhaps being base64 encoded.