### PR TITLE
natural major-suit raises

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,8 +2,8 @@ import System.Random(mkStdGen)
 
 --import qualified Topics.JacobyTransfers as JacobyTransfers
 --import qualified Topics.MinorTransfersScott as MinorTransfers
-import qualified Topics.StandardOpeners as StandardOpeners
-import qualified Topics.TexasTransfers as TexasTransfers
+--import qualified Topics.StandardOpeners as StandardOpeners
+--import qualified Topics.TexasTransfers as TexasTransfers
 
 {-
 import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
@@ -13,6 +13,7 @@ import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
 import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 -}
+import qualified Topics.MajorSuitRaises as MajorSuitRaises
 
 import ProblemSet(outputLatex)
 
@@ -24,6 +25,7 @@ main = let
              --SmpOpenings.topic
              --, Smp1CResponses.topic
               --Smp1CResponses.topicExtras
+              MajorSuitRaises.topic
              --, Mafia.topic
              --, MafiaResponses.topic
              --, Smp1DResponses.topic

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,8 +2,8 @@ import System.Random(mkStdGen)
 
 --import qualified Topics.JacobyTransfers as JacobyTransfers
 --import qualified Topics.MinorTransfersScott as MinorTransfers
---import qualified Topics.StandardOpeners as StandardOpeners
---import qualified Topics.TexasTransfers as TexasTransfers
+import qualified Topics.StandardOpeners as StandardOpeners
+import qualified Topics.TexasTransfers as TexasTransfers
 
 {-
 import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
@@ -21,11 +21,11 @@ import ProblemSet(outputLatex)
 main :: IO ()
 main = let
     topics = [ TexasTransfers.topic
-             --, StandardOpeners.topic
+             , StandardOpeners.topic
              --SmpOpenings.topic
              --, Smp1CResponses.topic
               --Smp1CResponses.topicExtras
-              MajorSuitRaises.topic
+             , MajorSuitRaises.topic
              --, Mafia.topic
              --, MafiaResponses.topic
              --, Smp1DResponses.topic

--- a/src/Topics/BidsMajorSuitRaises.hs
+++ b/src/Topics/BidsMajorSuitRaises.hs
@@ -1,0 +1,68 @@
+module Topics.BidsMajorSuitRaises(
+    b1H  -- Re-exported from StandardOpenings
+  , b1H2H
+  , b1H3H
+  , b1H3N
+  , b1S  -- Re-exported from StandardOpenings
+  , b1S2S
+  , b1S3S
+  , b1S3N
+) where
+
+
+import Auction(pointRange, minSuitLength, maxSuitLength, suitLength, Action,
+               makeCall, constrain)
+import StandardOpenings
+import qualified Terminology as T
+
+
+b1H :: Action
+b1H = StandardOpenings.b1h
+
+
+b1S :: Action
+b1S = StandardOpenings.b1s
+
+
+basicRaise :: T.Suit -> Action
+basicRaise suit = do
+    minSuitLength suit 3
+    maxSuitLength suit 4 -- With 5+, you might jump straight to game, per LoTT
+    pointRange 6 9
+    makeCall $ T.Bid 2 suit
+
+b1H2H :: Action
+b1H2H = basicRaise T.Hearts
+
+b1S2S :: Action
+b1S2S = basicRaise T.Spades
+
+
+limitRaise :: T.Suit -> Action
+limitRaise suit = do
+    -- Make these always 4-card raises, in anticipation of 2/1 using a forcing
+    -- 1N followed by a jump raise for 3-card raises. Also don't do 5-card
+    -- raises, because a lot of the time those should just blast game.
+    suitLength suit 4
+    pointRange 10 12
+    makeCall $ T.Bid 3 suit
+
+b1H3H :: Action
+b1H3H = limitRaise T.Hearts
+
+b1S3S :: Action
+b1S3S = limitRaise T.Spades
+
+
+blast3N :: T.Suit -> Action
+blast3N suit = do
+    pointRange 13 15
+    suitLength suit 3
+    constrain "fourtriple3" ["shape(", " any 4333)"]
+    makeCall $ T.Bid 3 T.Notrump
+
+b1H3N :: Action
+b1H3N = blast3N T.Hearts
+
+b1S3N :: Action
+b1S3N = blast3N T.Spades

--- a/src/Topics/BidsMajorSuitRaises.hs
+++ b/src/Topics/BidsMajorSuitRaises.hs
@@ -58,7 +58,7 @@ blast3N :: T.Suit -> Action
 blast3N suit = do
     pointRange 13 15
     suitLength suit 3
-    constrain "fourtriple3" ["shape(", " any 4333)"]
+    constrain "fourtriple3" ["shape(", ", any 4333)"]
     makeCall $ T.Bid 3 T.Notrump
 
 b1H3N :: Action

--- a/src/Topics/BidsMajorSuitRaises.hs
+++ b/src/Topics/BidsMajorSuitRaises.hs
@@ -12,16 +12,8 @@ module Topics.BidsMajorSuitRaises(
 
 import Auction(pointRange, minSuitLength, maxSuitLength, suitLength, Action,
                makeCall, constrain)
-import StandardOpenings
+import StandardOpenings(b1H, b1S)
 import qualified Terminology as T
-
-
-b1H :: Action
-b1H = StandardOpenings.b1h
-
-
-b1S :: Action
-b1S = StandardOpenings.b1s
 
 
 basicRaise :: T.Suit -> Action

--- a/src/Topics/MajorSuitRaises.hs
+++ b/src/Topics/MajorSuitRaises.hs
@@ -1,0 +1,76 @@
+module Topics.MajorSuitRaises(topic) where
+
+import Output((.+))
+import Topic(Topic, wrap, wrapVulDlr, Situations, makeTopic)
+import Auction(Action, makePass, alternatives, pointRange, constrain)
+import Situation(situation, (<~))
+import qualified Terminology as T
+import qualified Topics.BidsMajorSuitRaises as B
+import CommonBids(setOpener, cannotPreempt)
+
+
+noInterference :: Action
+noInterference = do
+    cannotPreempt
+    -- Building out the entire overcall structure just so we can forbid
+    -- any of it here is too complicated for now. Let's just say either
+    -- the opponent has at most 14 HCP, and either doesn't have a 5-card
+    -- suit or has at most 7 HCP.
+    pointRange 0 14
+    alternatives [
+        constrain "no_five_card_suit" [
+            "shape(", ", any 4441, any 4333, any 4432)"]
+      , pointRange 0 7]
+    makePass
+
+
+simpleRaise :: Situations
+simpleRaise = let
+    sit (opening, response) = let
+        action = do
+            setOpener T.North
+            _ <- opening
+            noInterference
+        explanation =
+            "With at least 3-card support for partner's suit but no " .+
+            "interest in game, raise partner's suit to the 2 level. " .+
+            "This will likely be passed out, but gives partner the chance " .+
+            "to show a huge hand, and also helps partner compete if the " .+
+            "opponents interfere."
+      in
+        situation "simpR" action response explanation
+  in
+    wrapVulDlr $ return sit <~ [(B.b1H, B.b1H2H), (B.b1S, B.b1S2S)]
+
+
+limitRaise :: Situations
+limitRaise = let
+    sit (opening, response) = let
+        action = do
+            setOpener T.North
+            _ <- opening
+            noInterference
+        explanation =
+            -- Don't mention needing at least 4-card support here: we're not
+            -- assuming that we're playing 2/1, so might not fold the 3-card
+            -- limit raises into the forcing 1N structure.
+            "With support for partner's suit and " .+
+            "invitational strength, make a limit raise by jumping in " .+
+            "partner's suit. They will pass with a minimum, and bid game " .+
+            "with extras."
+      in
+        situation "limtR" action response explanation
+  in
+    -- You should be an unpassed hand to make a limit raise; otherwise, consider
+    -- using Drury.
+    wrap $ return sit <~ [(B.b1H, B.b1H3H), (B.b1S, B.b1S3S)]
+                      <~ T.allVulnerabilities
+                      <~ [T.West, T.North]
+
+
+topic :: Topic
+topic = makeTopic "natural major-suit raises" "MajRai" situations
+  where
+    situations = wrap [ simpleRaise
+                      , limitRaise
+                      ]

--- a/src/Topics/MajorSuitRaises.hs
+++ b/src/Topics/MajorSuitRaises.hs
@@ -68,9 +68,37 @@ limitRaise = let
                       <~ [T.West, T.North]
 
 
+blast3N :: Situations
+blast3N = let
+    sit (opening, response, suit) = let
+        action = do
+            setOpener T.North
+            _ <- opening
+            noInterference
+        explanation =
+            "With 13-15 HCP, you probably want to be in game but not slam " .+
+            "when partner opens the bidding. You've got an 8-card fit in " .+
+            "partner's major, but with your 4333 shape, you're unlikely to " .+
+            "ruff anything in the short hand, so will likely take the same " .+
+            "number of tricks in notrump as you would in " .+ show suit .+
+            ". Offer " .+ T.Bid 3 T.Notrump .+ " to show this: partner can " .+
+            "pass with a balanced minimum, correct to " .+ T.Bid 4 suit .+
+            " with an unbalanced minimum, and invesigate slam if they have " .+
+            "a very strong hand."
+      in
+        situation "3N" action response explanation
+  in
+    -- You should be an unpassed hand to be game-forcing.
+    wrap $ return sit
+        <~ [(B.b1H, B.b1H3N, T.Hearts), (B.b1S, B.b1S3N, T.Spades)]
+        <~ T.allVulnerabilities
+        <~ [T.West, T.North]
+
+
 topic :: Topic
 topic = makeTopic "natural major-suit raises" "MajRai" situations
   where
     situations = wrap [ simpleRaise
                       , limitRaise
+                      , blast3N
                       ]


### PR DESCRIPTION
I need to specify natural because this doesn't cover Drury, 3-card limit raises using Forcing 1N in 2/1, Jacoby 2N, or delayed raises after a 2/1 bid with unbalanced game-forcing 3-card support. It's only simple raises, 4-card limit raises as an unpassed hand, and bidding 3N with a 4333 minimum game force.