### PR TITLE
Add a situation to standard openers for passing when you shouldn't open

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,7 @@ import System.Random(mkStdGen)
 --import qualified Topics.JacobyTransfers as JacobyTransfers
 --import qualified Topics.MinorTransfersScott as MinorTransfers
 import qualified Topics.StandardOpeners as StandardOpeners
-import qualified Topics.TexasTransfers as TexasTransfers
+--import qualified Topics.TexasTransfers as TexasTransfers
 
 {-
 import qualified Topics.StandardModernPrecision.OpeningBids as SmpOpenings
@@ -13,19 +13,19 @@ import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
 import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 -}
-import qualified Topics.MajorSuitRaises as MajorSuitRaises
+--import qualified Topics.MajorSuitRaises as MajorSuitRaises
 
 import ProblemSet(outputLatex)
 
 
 main :: IO ()
 main = let
-    topics = [ TexasTransfers.topic
-             , StandardOpeners.topic
+    topics = [ --TexasTransfers.topic
+              StandardOpeners.topic
              --SmpOpenings.topic
              --, Smp1CResponses.topic
               --Smp1CResponses.topicExtras
-             , MajorSuitRaises.topic
+             --, MajorSuitRaises.topic
              --, Mafia.topic
              --, MafiaResponses.topic
              --, Smp1DResponses.topic


### PR DESCRIPTION
In SMP, for example, you open all 11 counts and the good 10 counts. So, this is restricted to at most 10 HCP when balanced and at most 9 when unbalanced.

I need to come up with a standardized ordering for imports; some of them are getting hard to manage again.