### PR TITLE
Serve things related to the topics requested

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - bridge-practice
+    - extra
     - mtl
     - Spock
     - text

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -49,9 +49,8 @@ getTopic :: Int -> Either Int Topic
 getTopic i = maybeToEither i (topics !? i)
 
 
--- The idea here is that we'll look up each topic index, and get either a topic
--- or an error about it missing, and then we'll collect all that data into
--- either a list of topics or a list of missing indices.
+-- If there are any Left results, we'll return all of them, and otherwise we'll
+-- return all the Right results.
 collectResults :: [Either a b] -> Either [a] [b]
 collectResults [] = Right []
 collectResults (Left l : rest) = case collectResults rest of

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -4,7 +4,6 @@ module Main where
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.List.Utils(join, split)
 import Data.Map(Map, fromList, (!?))
-import qualified Data.Map -- for Data.Map.map without conflicts with map
 import Data.Text(pack)
 import Web.Spock(SpockM, text, var, get, root, (<//>), spock, runSpock, json)
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
@@ -43,7 +42,7 @@ topics = fromList . enumerate $ topicList
     enumerate = zipWith (,) [0..]
 
 topicNames :: Map Int String
-topicNames = Data.Map.map (toHtml . topicName) topics
+topicNames = fmap (toHtml . topicName) topics
 
 
 getTopic :: Int -> Either Int Topic

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Data.Either.Extra(maybeToEither)
-import Data.Map(Map, fromList, (!?), map)
+import Data.Either.Extra(maybeToEither, mapLeft)
+import Data.List.Utils(join, split)
+import Data.Map(Map, fromList, (!?))
+import qualified Data.Map -- for Data.Map.map without conflicts with map
 import Data.Text(pack)
 import Web.Spock(SpockM, text, var, get, root, (<//>), spock, runSpock, json)
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
@@ -59,6 +61,14 @@ collectResults (Left l : rest) = case collectResults rest of
 collectResults (Right r : rest) = case collectResults rest of
                                   Left l -> Left l
                                   Right rr -> Right (r : rr)
+
+
+findTopics :: String -> Either String [Topic]
+findTopics indices = let
+    results = collectResults . map (getTopic . read) . split "," $ indices
+    formatError = ("Unknown indices: " ++) . join "," . map show
+  in
+    mapLeft formatError results
 
 
 data MySession = EmptySession

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -26,11 +26,6 @@ import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 -}
 
 
--- I'm surprised this isn't defined in a popular, standard location.
-enumerate :: [a] -> [(Int, a)]
-enumerate = zipWith (,) [0..]
-
-
 topicList :: [Topic]
 topicList = [ StandardOpeners.topic
             , MajorSuitRaises.topic
@@ -40,6 +35,10 @@ topicList = [ StandardOpeners.topic
 
 topics :: Map Int Topic
 topics = fromList . enumerate $ topicList
+  where
+    -- I'm surprised this isn't defined in a popular, standard location.
+    enumerate :: [a] -> [(Int, a)]
+    enumerate = zipWith (,) [0..]
 
 topicNames :: Map Int String
 topicNames = Data.Map.map (toHtml . topicName) topics

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -85,5 +85,6 @@ app :: SpockM () MySession MyAppState ()
 app = do
     get root $ text "Hello World!"
     get "topics" $ json topicNames
-    get ("situation" <//> var) $ \requested ->
-        text . pack $ ("requested: " ++ requested)
+    get ("situation" <//> var) $ \requested -> case findTopics requested of
+        Left err -> text . pack $ err
+        Right topics -> json . map (toHtml . topicName) $ topics

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Data.Map(Map, fromList)
+import Data.Either.Extra(maybeToEither)
+import Data.Map(Map, fromList, (!?), map)
 import Data.Text(pack)
 import Web.Spock(SpockM, text, var, get, root, (<//>), spock, runSpock, json)
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
@@ -37,8 +38,15 @@ topicList = [ StandardOpeners.topic
             , TexasTransfers.topic
             ]
 
-topics :: Map Int String
-topics = fromList . enumerate . map (toHtml . topicName) $ topicList
+topics :: Map Int Topic
+topics = fromList . enumerate $ topicList
+
+topicNames :: Map Int String
+topicNames = Data.Map.map (toHtml . topicName) topics
+
+
+getTopic :: Int -> Either Int Topic
+getTopic i = maybeToEither i (topics !? i)
 
 
 -- The idea here is that we'll look up each topic index, and get either a topic
@@ -67,6 +75,6 @@ main = do
 app :: SpockM () MySession MyAppState ()
 app = do
     get root $ text "Hello World!"
-    get "topics" $ json topics
+    get "topics" $ json topicNames
     get ("situation" <//> var) $ \requested ->
         text . pack $ ("requested: " ++ requested)

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -41,6 +41,19 @@ topics :: Map Int String
 topics = fromList . enumerate . map (toHtml . topicName) $ topicList
 
 
+-- The idea here is that we'll look up each topic index, and get either a topic
+-- or an error about it missing, and then we'll collect all that data into
+-- either a list of topics or a list of missing indices.
+collectResults :: [Either a b] -> Either [a] [b]
+collectResults [] = Right []
+collectResults (Left l : rest) = case collectResults rest of
+                                 Left ll -> Left (l : ll)
+                                 Right _ -> Left [l]
+collectResults (Right r : rest) = case collectResults rest of
+                                  Left l -> Left l
+                                  Right rr -> Right (r : rr)
+
+
 data MySession = EmptySession
 data MyAppState = EmptyAppState
 


### PR DESCRIPTION
Currently, we just give back text describing malformed requests, or a list of topic names for well-formed requests. The next step is to go back and find all the places that need to implement `toHtml`, before we can actually construct situations. but that's a topic for a separate PR.