### PR TITLE
Prepare to show actual SituationInstances via the server

### DIFF
--- a/server/Main.hs
+++ b/server/Main.hs
@@ -100,4 +100,4 @@ app = do
             Right topics -> do
                 (sitInstList, rng') <- liftIO $ generate 1 topics rng
                 liftIO . writeIORef ioRng $ rng'
-                text . pack . toHtml . head $ sitInstList
+                text . pack . (show rng' ++ ) . toHtml . head $ sitInstList

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import Control.Monad.Trans(liftIO)
 import Data.Either.Extra(maybeToEither, mapLeft)
-import Data.IORef(IORef, newIORef)
+import Data.IORef(IORef, newIORef, readIORef)
 import Data.List.Utils(join, split)
 import Data.Map(Map, fromList, (!?))
 import Data.Text(pack)
@@ -92,6 +93,7 @@ app = do
     get "topics" $ json topicNames
     get ("situation" <//> var) $ \requested -> do
         (IoRng ioRng) <- getState
+        rng <- liftIO . readIORef $ ioRng
         case findTopics requested of
             Left err -> text . pack $ err
             Right topics -> json . map (toHtml . topicName) $ topics

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -61,6 +61,9 @@ collectResults (Right r : rest) = case collectResults rest of
                                   Right rr -> Right (r : rr)
 
 
+-- The argument should be a comma-separated list of indices. We return either a
+-- description of which indices we don't recognize, or a list of all the
+-- corresponding topics.
 findTopics :: String -> Either String [Topic]
 findTopics indices = let
     results = collectResults . map (getTopic . read) . split "," $ indices

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -3,7 +3,7 @@ module Main where
 
 import Control.Monad.Trans(liftIO)
 import Data.Either.Extra(maybeToEither, mapLeft)
-import Data.IORef(IORef, newIORef, readIORef)
+import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.List.Utils(join, split)
 import Data.Map(Map, fromList, (!?))
 import Data.Text(pack)
@@ -12,6 +12,7 @@ import Web.Spock(SpockM, text, var, get, root, (<//>), spock, runSpock, json, ge
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
 
 import Output(toHtml)
+import ProblemSet(generate)
 import Topic(Topic, topicName)
 
 import qualified Topics.JacobyTransfers as JacobyTransfers
@@ -96,4 +97,7 @@ app = do
         rng <- liftIO . readIORef $ ioRng
         case findTopics requested of
             Left err -> text . pack $ err
-            Right topics -> json . map (toHtml . topicName) $ topics
+            Right topics -> do
+                (sit, rng') <- liftIO $ generate 1 topics rng
+                liftIO . writeIORef ioRng $ rng'
+                json . map (toHtml . topicName) $ topics

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -98,6 +98,6 @@ app = do
         case findTopics requested of
             Left err -> text . pack $ err
             Right topics -> do
-                (sit, rng') <- liftIO $ generate 1 topics rng
+                (sitInstList, rng') <- liftIO $ generate 1 topics rng
                 liftIO . writeIORef ioRng $ rng'
-                json . map (toHtml . topicName) $ topics
+                text . pack . toHtml . head $ sitInstList

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -79,7 +79,7 @@ data MyAppState = EmptyAppState
 main :: IO ()
 main = do
     spockCfg <- defaultSpockCfg EmptySession PCNoDatabase EmptyAppState
-    runSpock 8080 (spock spockCfg app)
+    runSpock 8765 (spock spockCfg app)
 
 
 app :: SpockM () MySession MyAppState ()

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -2,9 +2,11 @@
 module Main where
 
 import Data.Either.Extra(maybeToEither, mapLeft)
+import Data.IORef(IORef, newIORef)
 import Data.List.Utils(join, split)
 import Data.Map(Map, fromList, (!?))
 import Data.Text(pack)
+import System.Random(StdGen, getStdGen)
 import Web.Spock(SpockM, text, var, get, root, (<//>), spock, runSpock, json)
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
 
@@ -73,12 +75,14 @@ findTopics indices = let
 
 
 data MySession = EmptySession
-data MyAppState = EmptyAppState
+data MyAppState = Rng (IORef StdGen)
 
 
 main :: IO ()
 main = do
-    spockCfg <- defaultSpockCfg EmptySession PCNoDatabase EmptyAppState
+    rng <- getStdGen
+    ref <- newIORef rng
+    spockCfg <- defaultSpockCfg EmptySession PCNoDatabase (Rng ref)
     runSpock 8765 (spock spockCfg app)
 
 

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -7,6 +7,7 @@
 module Output (
   OutputType(..)
 , Commentary(..)
+, toCommentary
 , Showable(..)
 , (.+)
 , Punct(..)
@@ -28,6 +29,10 @@ instance Monoid Commentary where
     mempty = Commentary [const ""]
 
 
+toCommentary :: Showable a => a -> Commentary
+toCommentary a = Commentary [flip output a]
+
+
 class Showable a where
     -- The minimal definition is either `output` or both `toLatex` and `toHtml`.
     toLatex :: a -> String
@@ -37,15 +42,12 @@ class Showable a where
     output :: OutputType -> a -> String
     output LaTeX = toLatex
     output Html = toHtml
-    toCommentary :: a -> Commentary
-    toCommentary a = Commentary [flip output a]
 
 instance Showable String where
     output = flip const
 
 instance Showable Commentary where
     output o (Commentary c) = concatMap (o &) $ c
-    toCommentary = id
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Commentary

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -29,29 +29,33 @@ instance Monoid Commentary where
     mempty = Commentary [const ""]
 
 
-toCommentary :: Showable a => a -> Commentary
-toCommentary a = Commentary [flip output a]
-
-
 class Showable a where
     -- The minimal definition is either `output` or both `toLatex` and `toHtml`.
     toLatex :: a -> String
     toLatex = output LaTeX
     toHtml :: a -> String
     toHtml = output Html
-    output :: OutputType -> a -> String
-    output LaTeX = toLatex
-    output Html = toHtml
 
 instance Showable String where
-    output = flip const
+    toLatex = id
+    toHtml = id
 
 instance Showable Commentary where
-    output o (Commentary c) = concatMap (o &) $ c
+    toLatex (Commentary c) = concatMap (LaTeX &) $ c
+    toHtml  (Commentary c) = concatMap (Html  &) $ c
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Commentary
 a .+ b = toCommentary a <> toCommentary b
+
+
+output :: Showable a => OutputType -> a -> String
+output LaTeX = toLatex
+output Html = toHtml
+
+
+toCommentary :: Showable a => a -> Commentary
+toCommentary a = Commentary [flip output a]
 
 
 data Punct = NDash

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -10,7 +10,7 @@ import Data.List.Utils(join)
 import System.Random(StdGen, genWord64)
 
 import DealerProg(eval)
-import Output(Showable, toLatex, Commentary)
+import Output(Showable(..), Commentary)
 import Situation(Situation(..))
 import Structures(Bidding, Deal)
 import Terminology(CompleteCall)
@@ -25,6 +25,7 @@ instance Showable SituationInstance where
         "\\problem{%\n" ++
             join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, toLatex s, ds] ++
             "%\n}"
+    toHtml _ = "todo"
 
 
 -- TODO: Find a way to make this cleaner. Monad transformers might be a relevant

--- a/src/Topics/JacobyTransfers.hs
+++ b/src/Topics/JacobyTransfers.hs
@@ -218,7 +218,8 @@ majors55inv = let
       \ hand and no spade fit (in which case a heart fit is guaranteed), or\
       \ bidding one of the majors at the 4 level with a maximum. This\
       \ wrong-sides the contract if we end up playing in spades."
-    bid = jacobyTransfer T.Hearts
+    bid = makeAlertableCall (T.Bid 2 T.Diamonds)
+                            ("Transfer to " ++ show T.Hearts)
   in
     stdWrap $ situation "55Inv" action bid explanation
 
@@ -240,7 +241,8 @@ majors55gf = let
             \ and then bid " .+ T.Bid 3 T.Hearts .+ " afterwards.\
             \ Partner will then have the options of which game to bid.\
             \ This wrong-sides the contract if we end up playing in hearts."
-        bid = jacobyTransfer T.Spades
+        bid = makeAlertableCall (T.Bid 2 T.Hearts)
+                                ("Transfer to " ++ show T.Spades)
       in
         situation "55GF" action bid explanation
   in


### PR DESCRIPTION
The next couple steps, I suspect, are to actually implement `toHtml` for all the Showable types that don't do that yet, and maybe get rid of `output`. but things still compile, I can get the "todo" to show up, and the RNG changes as you request new situations!

I also learned that, for the Jacoby Transfers situations with 5-5 in the majors, we've been asserting that the majors must have equal length and also asserting that they must _not_ have equal length, resulting in us skipping those every time they come up. I haven't noticed before because there is so much stuff printed to stdout when rendering the LaTeX. but the fix was easy enough.