### PR TITLE
Even more Stayman

### DIFF
--- a/src/Bids/OneNotrump.hs
+++ b/src/Bids/OneNotrump.hs
@@ -10,10 +10,13 @@ module Bids.OneNotrump(
   , b1N2C2H
   , b1N2C2H3H
   , b1N2C2H3S
+  , b1N2C2H3N
+  , b1N2C2H3N4S
   , b1N2C2H4H
   , b1N2C2S
   , b1N2C2S3H
   , b1N2C2S3S
+  , b1N2C2S3N
   , b1N2C2S4S
   , b1N2D
   , b1N2D2H
@@ -298,3 +301,25 @@ b1N2C2H3S = slamWithMajor T.Hearts T.Spades
 
 b1N2C2S3H :: Action
 b1N2C2S3H = slamWithMajor T.Spades T.Hearts
+
+
+wrongMajorTo3N :: T.Suit -> Action
+wrongMajorTo3N suit = do
+    pointRange 10 13
+    balancedHand
+    maxSuitLength suit 3
+    makeCall $ T.Bid 3 T.Notrump
+
+b1N2C2H3N :: Action
+b1N2C2H3N = wrongMajorTo3N T.Hearts
+
+b1N2C2S3N :: Action
+b1N2C2S3N = wrongMajorTo3N T.Spades
+
+
+b1N2C2H3N4S :: Action
+b1N2C2H3N4S = do
+    -- To get here, we must already have a 1N opener and 4 hearts, so all we
+    -- need now is 4 spades to match partner.
+    suitLength T.Spades 4
+    makeCall $ T.Bid 4 T.Spades

--- a/src/Bids/OneNotrump.hs
+++ b/src/Bids/OneNotrump.hs
@@ -248,14 +248,14 @@ b1N2C2D2N = do
 b1N2C2D3N :: Action
 b1N2C2D3N = do
     balancedHand
-    pointRange 10 13
+    pointRange 10 14
     makeCall $ T.Bid 3 T.Notrump
 
 
 b1N2C2D4N :: Action
 b1N2C2D4N = do
     balancedHand
-    pointRange 14 15
+    pointRange 15 16
     makeCall $ T.Bid 4 T.Notrump
 
 

--- a/src/Topics/Stayman.hs
+++ b/src/Topics/Stayman.hs
@@ -243,8 +243,109 @@ fitSlam = let
                       <~ T.allVulnerabilities <~ [T.North, T.West]
 
 
+wrongMajorGFH :: Situations
+wrongMajorGFH = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b1N
+            makePass
+            B.b1N2C
+            makePass
+            B.b1N2C2H
+            makePass
+        explanation =
+            "Partner opened a strong " .+ T.Bid 1 T.Notrump .+ ", and we " .+
+            "bid Stayman. Our only major is spades, though, and partner's " .+
+            "major is hearts, so we don't seem to have a fit. We're game " .+
+            "forcing with a balanced hand, so try signing off in " .+
+            T.Bid 3 T.Notrump .+ ". It's possible partner actually has " .+
+            "both majors, and will correct to " .+ T.Bid 4 T.Spades .+ "."
+      in situation "Wr3NH" action B.b1N2C2H3N explanation
+  in
+    stdWrap sit
+
+
+wrongMajorGFS :: Situations
+wrongMajorGFS = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b1N
+            makePass
+            B.b1N2C
+            makePass
+            B.b1N2C2S
+            makePass
+            maxSuitLength T.Spades 2
+        explanation =
+            "Partner opened a strong " .+ T.Bid 1 T.Notrump .+ ", and we " .+
+            "bid Stayman. Partner has 4+ spades, but does not have " .+
+            "4 hearts, so we definitely don't have a fit. We're " .+
+            "game forcing with a balanced hand, though, so sign off in " .+
+            T.Bid 3 T.Notrump .+ "."
+      in situation "Wr3NS" action B.b1N2C2S3N explanation
+  in
+    stdWrap sit
+
+
+-- Note: the following situation sounds plausible, until you realize that
+-- responder must be 4-3 in the majors. In some systems, they might have bid
+-- Puppet Stayman instead of regular Stayman. So, these hands are excluded from
+-- the regular Stayman topic to avoid overlap!
+{-
+wrongMajorGFSAmb :: Situations
+wrongMajorGFSAmb = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b1N
+            makePass
+            B.b1N2C
+            makePass
+            B.b1N2C2S
+            makePass
+            suitLength T.Spades 3
+        explanation =
+            "Partner opened a strong " .+ T.Bid 1 T.Notrump .+ ", and we " .+
+            "bid Stayman. Partner has 4+ spades, but does not have " .+
+            "4 hearts, so we don't obviously have a fit. We're " .+
+            "game forcing with a balanced hand, though, so sign off in " .+
+            T.Bid 3 T.Notrump .+ ". It's possible we have missed a 5" .+
+            NDash .+ "3 spade fit, but there's not much we can do about " .+
+            "that, and playing in notrump is probably alright."
+      in situation "Wr3NSo" action B.b1N2C2S3N explanation
+  in
+    stdWrap sit
+-}
+
+bothMajorsGF :: Situations
+bothMajorsGF = let
+    sit = let
+        action = do
+            setOpener T.South
+            B.b1N
+            makePass
+            B.b1N2C
+            makePass
+            B.b1N2C2H
+            makePass
+            B.b1N2C2H3N
+            makePass
+        explanation =
+            "We opened a strong " .+ T.Bid 1 T.Notrump .+ " with both " .+
+            "majors, and partner bid Stayman. We showed our cheapest one, " .+
+            "and partner jumped to " .+ T.Bid 3 T.Notrump .+ ", showing " .+
+            "game-forcing strength with no slam interest, and no heart fit. " .+
+            "To bid Stayman, they must have had a 4-card major, so they " .+
+            "must have spades! We've got a fit: let's play in that instead " .+
+            "of notrump."
+      in situation "3N4S" action B.b1N2C2H3N4S explanation
+  in
+    stdWrap sit
+
+
 -- TODO:
---   - opener has both majors, and tries the other one after 3N
 --   - responder bids another side suit, GF, after there's no fit
 --   - responder bids their major at the 2 level, showing 5-4 shape and
 --     invitational strength
@@ -261,8 +362,7 @@ fitSlam = let
 topic :: Topic
 topic = makeTopic "Stayman" "Stmn" situations
   where
-    situations = wrap [ garbageStayman
-                      , nongarbageStayman
+    situations = wrap [ wrap [garbageStayman, nongarbageStayman, bothMajorsGF]
                       , noMajor
                       , oneMajor
                       , bothMajors
@@ -272,4 +372,5 @@ topic = makeTopic "Stayman" "Stmn" situations
                       , fitInvite
                       , fitGf
                       , fitSlam
+                      , wrap [wrongMajorGFH, wrongMajorGFS]
                       ]

--- a/src/Topics/Stayman.hs
+++ b/src/Topics/Stayman.hs
@@ -249,7 +249,7 @@ fitSlam = let
 --   - responder bids their major at the 2 level, showing 5-4 shape and
 --     invitational strength
 --   - opener has both majors, responder bids another side suit after 2H, and
---     opener should go to 4S.
+--     opener should rebid 3S.
 --   - responder bids Texas over 2D
 --   - opener completes Texas
 --   - DON'T DO Smolen: that's a separate topic

--- a/src/Topics/Stayman.hs
+++ b/src/Topics/Stayman.hs
@@ -105,8 +105,8 @@ bothMajors = let
             "We opened a strong " .+ T.Bid 1 T.Notrump .+ ", and partner " .+
             "has bid Stayman, asking whether we have any major suits. " .+
             "We've got both, so bid the cheaper one, hearts. If partner " .+
-            "doesn't like that suit, they must have spades, and we'll " .+
-            "bid those later."
+            "doesn't like our suit, they must have spades, and we'll " .+
+            "be able to bid those later."
       in situation "2Maj" action B.b1N2C2H explanation
   in
     stdWrap sit

--- a/static/index.html
+++ b/static/index.html
@@ -61,7 +61,7 @@
               </tr>
             </table>
             <center>
-              <button onclick="displayProblem()">Next</button>
+              <button onclick="displayProblem()">Next Problem</button>
             </center>
           </td>
         </tr>


### PR DESCRIPTION
I hadn't realized just how many auctions there are that start with Stayman! I might be at this another week. :confounded: 

I also forgot that at the top of Bids/OneNotrump.hs, I define point ranges to be invitational, game forcing, etc., which perhaps I can use for all the Stayman follow-up bids too. However, those have been tuned for use over transfers, and seem too light for going to 3N without a fit after Stayman. Lee might be onto something with using Losing Trick Count instead of HCPs here. That'll require more thought, and can come in a future PR.