### PR TITLE
More on SMP 2D auctions

### DIFF
--- a/server/Main.hs
+++ b/server/Main.hs
@@ -30,6 +30,7 @@ import qualified Topics.StandardModernPrecision.OneDiamondResponses as Smp1DResp
 import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
 import qualified Topics.StandardModernPrecision.Lampe as Lampe
+import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDiamondOpeners
 
 -- I don't think I ever finished making these topics...
 --import qualified Topics.MinorTransfersScott as MinorTransfers
@@ -51,6 +52,7 @@ topicList = [ StandardOpeners.topic
             , Mafia.topic
             , MafiaResponses.topic
             , Lampe.topic
+            , TwoDiamondOpeners.topic
             ]
 
 topics :: Map Int Topic

--- a/src/Bids/StandardModernPrecision/BasicBids.hs
+++ b/src/Bids/StandardModernPrecision/BasicBids.hs
@@ -1,5 +1,6 @@
 module Bids.StandardModernPrecision.BasicBids(
     lessThanInvitational
+  , invitational
   , firstSeatOpener
   , oppsPass
   -- Opening bids
@@ -34,6 +35,14 @@ lessThanInvitational :: Action
 lessThanInvitational = do
     pointRange 0 10
     minLoserCount 9
+
+
+invitational :: Action
+invitational = do
+    pointRange 11 13
+    minLoserCount 7  -- TODO: Is this right? Maybe it should be exactly 8 losers
+    maxLoserCount 8
+
 
 -- Because we're not using the Rule of 20 and its ilk, we're going to skip the
 -- auctions that start with other folks passing for now, and maybe come back to

--- a/src/Bids/StandardModernPrecision/BasicBids.hs
+++ b/src/Bids/StandardModernPrecision/BasicBids.hs
@@ -24,7 +24,7 @@ import Action(Action, constrain)
 import CommonBids(cannotPreempt)
 import EDSL(forbid, pointRange, suitLength, minSuitLength, hasTopN,
             balancedHand, makeCall, makeAlertableCall, makePass, alternatives,
-            minLoserCount, forEach, forbidAll)
+            minLoserCount, maxLoserCount, forEach, forbidAll)
 import Output(Punct(..), (.+))
 import Situation(Situation, (<~))
 import qualified Terminology as T

--- a/src/Bids/StandardModernPrecision/TwoDiamonds.hs
+++ b/src/Bids/StandardModernPrecision/TwoDiamonds.hs
@@ -123,18 +123,17 @@ b2D3H :: Action
 b2D3H = do
     pointRange 7 9
     minSuitLength T.Hearts 5
-    -- TODO: is this actually alertable? Maybe not...
-    makeAlertableCall (T.Bid 3 T.Hearts)
-                      ("mixed raise: 7" .+ NDash .+ "9 HCP, 5 hearts")
+    -- NOTE: is this *not* alertable, per
+    -- https://web2.acbl.org/documentLibrary/play/Alert-Procedures.pdf
+    makeCall $ T.Bid 3 T.Hearts
 
 
 b2D3S :: Action
 b2D3S = do
     pointRange 7 9
     minSuitLength T.Spades 5
-    -- TODO: is this actually alertable? Maybe not...
-    makeAlertableCall (T.Bid 3 T.Spades)
-                      ("mixed raise: 7" .+ NDash .+ "9 HCP, 5 spades")
+    -- NOTE: is this *not* alertable, either
+    makeCall $ T.Bid 3 T.Spades
 
 
 b2D3N :: Action

--- a/src/Bids/StandardModernPrecision/TwoDiamonds.hs
+++ b/src/Bids/StandardModernPrecision/TwoDiamonds.hs
@@ -7,11 +7,16 @@ module Bids.StandardModernPrecision.TwoDiamonds(
 , b2D2S
 , bP2D2S
 , b2D2N
+, b2D2N3C
+, b2D2N3D
+, b2D2N3H
+, b2D2N3S
 , b2D3C
 , bP2D3C
 , b2D3H
 , b2D3S
 , b2D3N
+, name44Rkc
 ) where
 
 
@@ -20,8 +25,9 @@ import Bids.StandardModernPrecision.BasicBids(b2D, lessThanInvitational)
 import CommonBids(cannotPreempt)
 import EDSL(suitLength, minSuitLength, maxSuitLength, makeCall, pointRange,
             makeAlertableCall, atLeastAsLong, longerThan, forbid, forbidAll,
-            balancedHand, soundHolding, makePass, alternatives, forEach)
-import Output(Punct(..), (.+))
+            balancedHand, soundHolding, makePass, alternatives, forEach,
+            minLoserCount)
+import Output(Punct(..), (.+), Commentary)
 import qualified Terminology as T
 
 
@@ -146,3 +152,38 @@ b2D2N = do
     forbidAll [b2D3N]
     pointRange 11 40
     makeAlertableCall (T.Bid 2 T.Notrump) "inv+, asks for strength and majors"
+
+
+b2D2N3C :: Action
+b2D2N3C = do
+    -- You should have the lower half of your strength to not accept an invite.
+    alternatives [pointRange 10 12, pointRange 10 13 >> minLoserCount 7]
+    makeAlertableCall (T.Bid 3 T.Clubs)
+                      ("minimum strength, likely 10" .+ NDash .+ "12 HCP")
+
+
+b2D2N3D :: Action
+b2D2N3D = do
+    forbid b2D2N3C  -- We'd accept an invite to game
+    forEach T.majorSuits (`suitLength` 4)
+    makeAlertableCall (T.Bid 3 T.Diamonds)
+                      ("maximum strength, 4" .+ NDash .+ "4 in the majors")
+
+
+b2D2N3H :: Action
+b2D2N3H = do
+    forbid b2D2N3C  -- We'd accept an invite to game
+    suitLength T.Hearts 3
+    makeAlertableCall (T.Bid 3 T.Hearts) "maximum strength, 4315 shape exactly"
+
+
+b2D2N3S :: Action
+b2D2N3S = do
+    forbid b2D2N3C  -- We'd accept an invite to game
+    suitLength T.Spades 3
+    makeAlertableCall (T.Bid 3 T.Spades) "maximum strength, 3415 shape exactly"
+
+
+-- This name is too long to write over and over.
+name44Rkc :: Commentary
+name44Rkc = T.Bid 4 T.Clubs .+ "/" .+ T.Bid 4 T.Diamonds .+ "/RKC"

--- a/src/Bids/StandardModernPrecision/TwoDiamonds.hs
+++ b/src/Bids/StandardModernPrecision/TwoDiamonds.hs
@@ -10,6 +10,9 @@ module Bids.StandardModernPrecision.TwoDiamonds(
 , b2D2N
 , b2D2N3C
 , b2D2N3C3D
+, b2D2N3C3D3H
+, b2D2N3C3D3S
+, b2D2N3C3D3N
 , b2D2N3D
 , b2D2N3H
 , b2D2N3S
@@ -164,7 +167,7 @@ b2D2N3C = do
     -- You should have the lower half of your strength to not accept an invite.
     alternatives [pointRange 10 12, pointRange 10 13 >> minLoserCount 7]
     makeAlertableCall (T.Bid 3 T.Clubs)
-                      ("minimum strength, likely 10" .+ NDash .+ "12 HCP")
+                      ("minimum, likely 10" .+ NDash .+ "12 HCP")
 
 
 b2D2N3D :: Action
@@ -193,3 +196,21 @@ b2D2N3C3D :: Action
 b2D2N3C3D = do
     pointRange 14 40
     makeAlertableCall (T.Bid 3 T.Diamonds) "artificial ask about majors"
+
+
+b2D2N3C3D3H :: Action
+b2D2N3C3D3H = do
+    suitLength T.Hearts 3
+    makeAlertableCall (T.Bid 3 T.Hearts) "shorter hearts: 4315 shape exactly"
+
+
+b2D2N3C3D3S :: Action
+b2D2N3C3D3S = do
+    suitLength T.Spades 3
+    makeAlertableCall (T.Bid 3 T.Spades) "shorter spades: 3415 shape exactly"
+
+
+b2D2N3C3D3N :: Action
+b2D2N3C3D3N = do
+    forEach T.majorSuits (`suitLength` 4)
+    makeAlertableCall (T.Bid 3 T.Notrump) ("4" .+ NDash .+ "4 in the majors")

--- a/src/Bids/StandardModernPrecision/TwoDiamonds.hs
+++ b/src/Bids/StandardModernPrecision/TwoDiamonds.hs
@@ -1,5 +1,6 @@
 module Bids.StandardModernPrecision.TwoDiamonds(
-  noDirectOvercall
+  name44Rkc
+, noDirectOvercall
 , b2D  -- Re-exported from BasicBids
 , b2D2H
 , bP2D2H
@@ -8,6 +9,7 @@ module Bids.StandardModernPrecision.TwoDiamonds(
 , bP2D2S
 , b2D2N
 , b2D2N3C
+, b2D2N3C3D
 , b2D2N3D
 , b2D2N3H
 , b2D2N3S
@@ -16,7 +18,6 @@ module Bids.StandardModernPrecision.TwoDiamonds(
 , b2D3H
 , b2D3S
 , b2D3N
-, name44Rkc
 ) where
 
 
@@ -29,6 +30,11 @@ import EDSL(suitLength, minSuitLength, maxSuitLength, makeCall, pointRange,
             minLoserCount)
 import Output(Punct(..), (.+), Commentary)
 import qualified Terminology as T
+
+
+-- This name is too long to write over and over.
+name44Rkc :: Commentary
+name44Rkc = T.Bid 4 T.Clubs .+ "/" .+ T.Bid 4 T.Diamonds .+ "/RKC"
 
 
 noDirectOvercall :: Action
@@ -183,6 +189,7 @@ b2D2N3S = do
     makeAlertableCall (T.Bid 3 T.Spades) "maximum strength, 3415 shape exactly"
 
 
--- This name is too long to write over and over.
-name44Rkc :: Commentary
-name44Rkc = T.Bid 4 T.Clubs .+ "/" .+ T.Bid 4 T.Diamonds .+ "/RKC"
+b2D2N3C3D :: Action
+b2D2N3C3D = do
+    pointRange 14 40
+    makeAlertableCall (T.Bid 3 T.Diamonds) "artificial ask about majors"

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -314,13 +314,39 @@ gfAnyway = let
                       <~ [T.North, T.West]  -- We're both unpassed hands
 
 
+gfAnywayResponses :: Situations
+gfAnywayResponses = let
+    sit bid = let
+        action = do
+            setOpener T.South
+            B.b2D
+            B.noDirectOvercall
+            B.b2D2N
+            B.noDirectOvercall
+            B.b2D2N3C
+            B.noDirectOvercall
+            B.b2D2N3C3D
+            B.noDirectOvercall
+        explanation =
+            "We have shown a minimum, but partner is game forcing anyway. " .+
+            "Use Smolen-like bids to show partner our major-suit shape: " .+
+            "bid a 3-card major, or " .+ T.Bid 3 T.Notrump .+ " to show " .+
+            "both majors. Partner now knows our strength and shape, and " .+
+            "can use " .+ B.name44Rkc .+ " to place the final contract " .+
+            "(or sign off in " .+ T.Bid 3 T.Notrump .+ ")."
+      in
+        situation "reans" action bid explanation
+  in
+    wrap $ return sit <~ [B.b2D2N3C3D3H, B.b2D2N3C3D3S, B.b2D2N3C3D3N]
+                      <~ T.allVulnerabilities
+                      <~ [T.South, T.East]  -- We're both unpassed hands
+
+
 -- TODO:
 --   - Responder immediately bids a major-suit game (see immediateGameSignoff)
---   - Responder bids 3D over opener's 3C
 --   - Responder signs off over opener's 3C (including in 3N if responder had
 --     a slam invite!) (would other game-level rebids be signoff? Probably, but
 --     it's much easier to try 3D before signing off).
---   - Opener rebids after responder rebids 3D
 --   - Rework setOpener, wrapVulDlr, stdWrap, stdWrapNW, stdWrapSE
 --   - DON'T DO 4C/4D/RKC: that should be a separate topic
 
@@ -344,11 +370,13 @@ topic = makeTopic description "SMP2D" situations
                              , passBlackSignoff
                              , passBlackSignoff
                              , passSignoffHearts
-                             , correctSignoffHearts]
+                             , correctSignoffHearts
+                             ]
                       , mixedRaise
                       , immediateGameSignoff
                       , bid2N
                       , minimumResponse
                       , maximumResponse
                       , gfAnyway
+                      , gfAnywayResponses
                       ]

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -296,6 +296,7 @@ maximumResponse = let
 --     a slam invite!) (would other game-level rebids be signoff? Probably, but
 --     it's much easier to try 3D before signing off).
 --   - Opener rebids after responder rebids 3D
+--   - Rework setOpener, wrapVulDlr, stdWrap, stdWrapNW, stdWrapSE
 --   - DON'T DO 4C/4D/RKC: that should be a separate topic
 
 

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -282,10 +282,35 @@ maximumResponse = let
             "length. Partner's next bid will either be signing off in " .+
             T.Bid 3 T.Notrump .+ " or " .+ B.name44Rkc .+ "."
       in
-        situation "min" action bid explanation
+        situation "max" action bid explanation
   in
     wrap $ return sit <~ [B.b2D2N3D, B.b2D2N3H, B.b2D2N3S]
                       <~ T.allVulnerabilities
+                      <~ [T.North, T.West]  -- We're both unpassed hands
+
+
+gfAnyway :: Situations
+gfAnyway = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b2D
+            B.noDirectOvercall
+            B.b2D2N
+            B.noDirectOvercall
+            B.b2D2N3C
+            B.noDirectOvercall
+        explanation =
+            "Partner has shown a minimum, but we're game forcing anyway. " .+
+            "Bid " .+ T.Bid 3 T.Diamonds .+ " to re-ask partner about " .+
+            "their major suits. When they reply, you'll know their exact " .+
+            "shape and their strength to within 1 HCP. You'll then know " .+
+            "what the final contract should be, and can use " .+ B.name44Rkc .+
+            " to place it."
+      in
+        situation "reask" action B.b2D2N3C3D explanation
+  in
+    wrap $ return sit <~ T.allVulnerabilities
                       <~ [T.North, T.West]  -- We're both unpassed hands
 
 
@@ -325,4 +350,5 @@ topic = makeTopic description "SMP2D" situations
                       , bid2N
                       , minimumResponse
                       , maximumResponse
+                      , gfAnyway
                       ]

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -356,15 +356,17 @@ topic = makeTopic description "SMP2D" situations
   where
     description = ("SMP " .+ T.Bid 2 T.Diamonds .+ " auctions")
     situations = wrap [ open
-                      -- Responder signs off
-                      , wrap [ wrap [ immediateSignoffSpades34
+                      -- Responder signs off (equiprobable in all suits)
+                      , wrap [ wrap [ immediateSignoffSpades5
+                                    -- Equiprobable in all spade lengths
                                     , immediateSignoffSpades34
-                                    , immediateSignoffSpades5
+                                    , immediateSignoffSpades34
                                     ]
                              , immediateSignoffClubs
                              , immediateSignoffHearts
                              ]
-                      -- Opener passes responder's signoff
+                      -- Opener passes responder's signoff (equiprobable in all
+                      -- suits)
                       , wrap [ passBlackSignoff
                              , passBlackSignoff
                              , passBlackSignoff

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -342,11 +342,34 @@ gfAnywayResponses = let
                       <~ [T.South, T.East]  -- We're both unpassed hands
 
 
+invSignoff :: Situations
+invSignoff = let
+    sit bid = let
+        action = do
+            setOpener T.North
+            B.b2D
+            B.noDirectOvercall
+            B.b2D2N
+            B.noDirectOvercall
+            B.b2D2N3C
+            B.noDirectOvercall
+        explanation =
+            "We were invitational, but partner has shown a minimum, " .+
+            "indicating that they would not accept an invite to game. " .+
+            "Sign off in partscore."
+      in
+        situation "invso" action bid explanation
+  in
+    wrap $ return sit <~ [B.b2D2N3CP, B.b2D2N3C3H, B.b2D2N3C3S]
+                      <~ T.allVulnerabilities
+                      <~ [T.North, T.West]  -- We're both unpassed hands
+
+
 -- TODO:
 --   - Responder immediately bids a major-suit game (see immediateGameSignoff)
---   - Responder signs off over opener's 3C (including in 3N if responder had
---     a slam invite!) (would other game-level rebids be signoff? Probably, but
---     it's much easier to try 3D before signing off).
+--   - Responder signs off in 3N over opener's 3C (they had a slam invite)
+--     (would other game-level rebids be signoff? Probably, but it's much easier
+--     to try 3D before signing off).
 --   - Rework setOpener, wrapVulDlr, stdWrap, stdWrapNW, stdWrapSE
 --   - DON'T DO 4C/4D/RKC: that should be a separate topic
 
@@ -381,4 +404,5 @@ topic = makeTopic description "SMP2D" situations
                       , maximumResponse
                       , gfAnyway
                       , gfAnywayResponses
+                      , invSignoff
                       ]

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -243,10 +243,58 @@ bid2N = let
                       <~ [T.North, T.West]  -- We're an unpassed hand
 
 
+minimumResponse :: Situations
+minimumResponse = let
+    sit = let
+        action = do
+            setOpener T.South
+            B.b2D
+            B.noDirectOvercall
+            B.b2D2N
+            B.noDirectOvercall
+        explanation =
+            "Partner has asked us to describe our strength more. We're in " .+
+            "the bottom half of our range, so bid " .+ T.Bid 3 T.Clubs .+
+            ". If partner was only invitational, they'll sign off after " .+
+            "this (possibly by passing!), and if they're game forcing, " .+
+            "they'll relay to ask us about our majors."
+      in
+        situation "min" action B.b2D2N3C explanation
+  in
+    wrap $ return sit <~ T.allVulnerabilities
+                      <~ [T.North, T.West]  -- We're both unpassed hands
+
+
+maximumResponse :: Situations
+maximumResponse = let
+    sit bid = let
+        action = do
+            setOpener T.South
+            B.b2D
+            B.noDirectOvercall
+            B.b2D2N
+            B.noDirectOvercall
+        explanation =
+            "Partner has asked us to describe our strength and majors " .+
+            "more. We're in the top half of our range (we'd accept a game " .+
+            "invite). Bid similar to Smolen: bid our shorter major if we " .+
+            "have one, or " .+ T.Bid 3 T.Diamonds .+ " if they're equal " .+
+            "length. Partner's next bid will either be signing off in " .+
+            T.Bid 3 T.Notrump .+ " or " .+ B.name44Rkc .+ "."
+      in
+        situation "min" action bid explanation
+  in
+    wrap $ return sit <~ [B.b2D2N3D, B.b2D2N3H, B.b2D2N3S]
+                      <~ T.allVulnerabilities
+                      <~ [T.North, T.West]  -- We're both unpassed hands
+
+
 -- TODO:
 --   - Responder immediately bids a major-suit game (see immediateGameSignoff)
---   - Opener responds to 2N
 --   - Responder bids 3D over opener's 3C
+--   - Responder signs off over opener's 3C (including in 3N if responder had
+--     a slam invite!) (would other game-level rebids be signoff? Probably, but
+--     it's much easier to try 3D before signing off).
 --   - Opener rebids after responder rebids 3D
 --   - DON'T DO 4C/4D/RKC: that should be a separate topic
 
@@ -274,4 +322,6 @@ topic = makeTopic description "SMP2D" situations
                       , mixedRaise
                       , immediateGameSignoff
                       , bid2N
+                      , minimumResponse
+                      , maximumResponse
                       ]


### PR DESCRIPTION
Not counting game-level 4C/4D/RKC (which should be a separate topic) and game-level signoffs, I think this is done.

I need to do some more refactoring and cleanup, especially about setting the opener in SMP auctions (which I don't think are able to open without still using the Rule of 20).