### PR TITLE
Syntactic sugar when ensuring one hand is unpassed

### DIFF
--- a/make_pdf/Main.hs
+++ b/make_pdf/Main.hs
@@ -35,7 +35,7 @@ main = let
               , Smp2DOpen.topic
               , Meckwell.topic
               ]
-    topics = [Smp2DOpen.topic]
+    topics = [ForcingOneNotrump.topic]
   in do
     outputLatex 100 topics "test" (mkStdGen 0)
     return ()

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,6 @@ dependencies:
 - process
 - random
 - transformers
-- wai-middleware-static
 
 library:
   source-dirs: src
@@ -58,6 +57,7 @@ executables:
     - mtl
     - Spock
     - text
+    - wai-middleware-static
 
 tests:
   bridge-practice-test:

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -48,9 +48,9 @@ topicList = [ StandardOpeners.topic
             , SmpOpenings.topic
             , Smp1CResponses.topic
             , Smp1CResponses.topicExtras
-            , Smp1DResponses.topic
             , Mafia.topic
             , MafiaResponses.topic
+            , Smp1DResponses.topic
             , Lampe.topic
             , TwoDiamondOpeners.topic
             ]

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -46,5 +46,7 @@ outputLatex numHands topics filename g = do
     template <- readFile "template.tex"
     let doc = replace "%<TOPICS>" topicNames .
               replace "%<PROBLEMS>" problemSet $ template
-    writeFile (filename ++ ".tex") doc
+    let fullFilename = filename ++ ".tex"
+    writeFile fullFilename doc
+    putStrLn("Output written to " ++ fullFilename)
     return doc

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -53,10 +53,16 @@ wrapVulDlr :: State StdGen (Vulnerability -> Direction -> Situation) ->
     Situations
 wrapVulDlr sit = wrap $ sit <~ allVulnerabilities <~ allDirections
 
+-- By ensuring that only North or West could be dealer, if we make North open
+-- the bidding, we ensure South is an unpassed hand. This is useful when
+-- practicing game-forcing auctions when partner opens the bidding.
 wrapVulNW :: State StdGen (Vulnerability -> Direction -> Situation) ->
     Situations
 wrapVulNW sit = wrap $ sit <~ allVulnerabilities <~ [North, West]
 
+-- By ensuring that only South or East could be dealer, if we make South open
+-- the bidding, we ensure that North is an unpassed hand. This is useful when
+-- practicing game-forcing auctions when we open the bidding.
 wrapVulSE :: State StdGen (Vulnerability -> Direction -> Situation) ->
     Situations
 wrapVulSE sit = wrap $ sit <~ allVulnerabilities <~ [South, East]

--- a/src/Topic.hs
+++ b/src/Topic.hs
@@ -9,7 +9,11 @@ module Topic(
 , choose
 , wrap
 , wrapVulDlr
+, wrapVulNW
+, wrapVulSE
 , stdWrap
+, stdWrapNW
+, stdWrapSE
 , Topic(..)
 , makeTopic
 ) where
@@ -20,7 +24,8 @@ import System.Random(StdGen)
 import Output(Commentary, toCommentary, Showable)
 import Random(pickItem)
 import Situation(Situation, (<~))
-import Terminology(Direction, allDirections, Vulnerability, allVulnerabilities)
+import Terminology(
+    Direction(..), allDirections, Vulnerability, allVulnerabilities)
 
 
 data Situations = RawSit Situation
@@ -41,15 +46,31 @@ instance Situationable Situations where
     wrap = id
 
 
--- The most common Situation parameters are letting anyone be the dealer and
--- letting anyone be vulnerable. Make some syntactic sugar for that.
+-- The most common Situation parameters are letting anyone be vulnerable, and
+-- either letting anyone be the dealer, ensuring North is an unpassed hand, or
+-- ensuring South is an unpassed hand. Make some syntactic sugar for that.
 wrapVulDlr :: State StdGen (Vulnerability -> Direction -> Situation) ->
     Situations
 wrapVulDlr sit = wrap $ sit <~ allVulnerabilities <~ allDirections
+
+wrapVulNW :: State StdGen (Vulnerability -> Direction -> Situation) ->
+    Situations
+wrapVulNW sit = wrap $ sit <~ allVulnerabilities <~ [North, West]
+
+wrapVulSE :: State StdGen (Vulnerability -> Direction -> Situation) ->
+    Situations
+wrapVulSE sit = wrap $ sit <~ allVulnerabilities <~ [South, East]
+
 -- and more syntactic sugar for a Situation that is _only_ parameterized on
 -- those features.
 stdWrap :: (Vulnerability -> Direction -> Situation) -> Situations
 stdWrap = wrapVulDlr . return
+
+stdWrapNW :: (Vulnerability -> Direction -> Situation) -> Situations
+stdWrapNW = wrapVulNW . return
+
+stdWrapSE :: (Vulnerability -> Direction -> Situation) -> Situations
+stdWrapSE = wrapVulSE . return
 
 
 data Topic = Topic { topicName :: Commentary

--- a/src/Topics/ForcingOneNotrump.hs
+++ b/src/Topics/ForcingOneNotrump.hs
@@ -6,7 +6,8 @@ import EDSL(suitLength, maxSuitLength, pointRange, makeCall, forEach)
 import Output((.+), Punct(..))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, Situations, makeTopic, stdWrapNW, stdWrapSE,
+             wrapVulNW, wrapVulSE)
 
 
 bid1NHearts :: Situations
@@ -25,8 +26,7 @@ bid1NHearts = let
       in
         situation "H1N" action B.b1H1N explanation
   in
-    -- For us to bid a forcing 1N, we must be an unpassed hand.
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.West]
+    stdWrapNW sit  -- For us to bid a forcing 1N, we must be an unpassed hand.
 
 
 bid1NSpades :: Situations
@@ -44,8 +44,8 @@ bid1NSpades = let
       in
         situation "S1N" action B.b1S1N explanation
   in
-    -- For us to bid a forcing 1N, we must be an unpassed hand.
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.West]
+    stdWrapNW sit  -- For us to bid a forcing 1N, we must be an unpassed hand.
+
 
 rebid2N :: Situations
 rebid2N = let
@@ -64,10 +64,8 @@ rebid2N = let
       in
         situation "rb2N" action B.b1M1N2N explanation
   in
-    wrap $ return sit
+    wrapVulSE $ return sit
         <~ [(B.b1H, B.b1H1N, T.Hearts), (B.b1S, B.b1S1N, T.Spades)]
-        <~ T.allVulnerabilities
-        <~ [T.South, T.East]
 
 
 jumpShift :: Situations
@@ -88,14 +86,12 @@ jumpShift = let
       in
         situation "js" action rebid explanation
   in
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N3C, T.Hearts)
-                         , (B.b1H, B.b1H1N, B.b1H1N3D, T.Hearts)
-                         , (B.b1S, B.b1S1N, B.b1S1N3C, T.Spades)
-                         , (B.b1S, B.b1S1N, B.b1S1N3D, T.Spades)
-                         , (B.b1S, B.b1S1N, B.b1S1N3H, T.Spades)
-                         ]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N3C, T.Hearts)
+                              , (B.b1H, B.b1H1N, B.b1H1N3D, T.Hearts)
+                              , (B.b1S, B.b1S1N, B.b1S1N3C, T.Spades)
+                              , (B.b1S, B.b1S1N, B.b1S1N3D, T.Spades)
+                              , (B.b1S, B.b1S1N, B.b1S1N3H, T.Spades)
+                              ]
 
 
 majorReverse :: Situations
@@ -117,7 +113,7 @@ majorReverse = let
       in
         situation "rev" action B.b1H1N2S explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.South, T.East]
+    stdWrapSE sit
 
 
 jumpRebid :: Situations
@@ -136,10 +132,8 @@ jumpRebid = let
       in
         situation "jrb" action rebid explanation
   in
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N3H, T.Hearts)
-                         , (B.b1S, B.b1S1N, B.b1S1N3S, T.Spades) ]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N3H, T.Hearts)
+                              , (B.b1S, B.b1S1N, B.b1S1N3S, T.Spades) ]
 
 
 limitRaise3 :: Situations
@@ -161,10 +155,8 @@ limitRaise3 = let
         situation "lr3" action response explanation
   in
     -- For us to bid a forcing 1N, we must be an unpassed hand.
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, T.Hearts)
-                         , (B.b1S, B.b1S1N, T.Spades) ]
-                      <~ T.allVulnerabilities
-                      <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [ (B.b1H, B.b1H1N, T.Hearts)
+                              , (B.b1S, B.b1S1N, T.Spades) ]
 
 
 raise2 :: Situations
@@ -192,10 +184,8 @@ raise2 = let
         situation "mr2" action response explanation
   in
     -- For us to bid a forcing 1N, we must be an unpassed hand.
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, T.Hearts)
-                         , (B.b1S, B.b1S1N, T.Spades) ]
-                      <~ T.allVulnerabilities
-                      <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [ (B.b1H, B.b1H1N, T.Hearts)
+                              , (B.b1S, B.b1S1N, T.Spades) ]
 
 
 nonjumpRebid :: Situations
@@ -218,10 +208,8 @@ nonjumpRebid = let
       in
         situation "nrb" action rebid explanation
   in
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N2H, T.Hearts)
-                         , (B.b1S, B.b1S1N, B.b1S1N2S, T.Spades) ]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N2H, T.Hearts)
+                              , (B.b1S, B.b1S1N, B.b1S1N2S, T.Spades) ]
 
 
 secondSuitRebid :: Situations
@@ -243,14 +231,12 @@ secondSuitRebid = let
       in
         situation "b2nd" action rebid explanation
   in
-    wrap $ return sit <~ [ (B.b1S, B.b1S1N, B.b1S1N2H, T.Spades)
-                         , (B.b1S, B.b1S1N, B.b1S1N2D, T.Spades)
-                         , (B.b1S, B.b1S1N, B.b1S1N2C, T.Spades)
-                         , (B.b1H, B.b1H1N, B.b1H1N2C, T.Hearts)
-                         , (B.b1H, B.b1H1N, B.b1H1N2D, T.Hearts)
-                         ]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1S, B.b1S1N, B.b1S1N2H, T.Spades)
+                              , (B.b1S, B.b1S1N, B.b1S1N2D, T.Spades)
+                              , (B.b1S, B.b1S1N, B.b1S1N2C, T.Spades)
+                              , (B.b1H, B.b1H1N, B.b1H1N2C, T.Hearts)
+                              , (B.b1H, B.b1H1N, B.b1H1N2D, T.Hearts)
+                              ]
 
 
 heartsSpadesThird :: Situations
@@ -273,11 +259,9 @@ heartsSpadesThird = let
       in
         situation "b2nd4" action rebid explanation
   in
-    wrap $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N2C)
-                         , (B.b1H, B.b1H1N, B.b1H1N2D)
-                         ]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1H, B.b1H1N, B.b1H1N2C)
+                              , (B.b1H, B.b1H1N, B.b1H1N2D)
+                              ]
 
 
 wantFlannery :: Situations
@@ -307,12 +291,13 @@ wantFlannery = let
       in
         situation "flan" action (makeCall $ T.Bid 2 T.Hearts) explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.South, T.East]
+    stdWrapSE sit
 
 
--- more situations:
---                  opener accepts/rejects invite
---                  responder weak with long suit,
+-- TODO:
+--   - opener accepts/rejects invite
+--   - responder weak with long suit
+--   - responder is a passed hand so 1N is natural (and opener's rebid here)
 
 
 topic :: Topic

--- a/src/Topics/MajorSuitRaises.hs
+++ b/src/Topics/MajorSuitRaises.hs
@@ -5,7 +5,7 @@ import CommonBids(setOpener, noInterference)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, wrapVulDlr, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulDlr, wrapVulNW, Situations, makeTopic)
 
 
 simpleRaise :: Situations
@@ -48,10 +48,8 @@ limitRaise = let
   in
     -- You should be an unpassed hand to make a limit raise; otherwise, consider
     -- using Drury.
-    wrap $ return sit <~ [ (B.b1H, B.b1H3H, T.Hearts)
-                         , (B.b1S, B.b1S3S, T.Spades)]
-                      <~ T.allVulnerabilities
-                      <~ [T.West, T.North]
+    wrapVulNW $ return sit <~ [ (B.b1H, B.b1H3H, T.Hearts)
+                              , (B.b1S, B.b1S3S, T.Spades)]
 
 
 blast3N :: Situations
@@ -75,10 +73,8 @@ blast3N = let
         situation "3N" action response explanation
   in
     -- You should be an unpassed hand to be game-forcing.
-    wrap $ return sit
+    wrapVulNW $ return sit
         <~ [(B.b1H, B.b1H3N, T.Hearts), (B.b1S, B.b1S3N, T.Spades)]
-        <~ T.allVulnerabilities
-        <~ [T.West, T.North]
 
 
 topic :: Topic

--- a/src/Topics/MinorTransfersScott.hs
+++ b/src/Topics/MinorTransfersScott.hs
@@ -7,7 +7,8 @@ import EDSL(forbid, makeCall, makeAlertableCall, makePass, pointRange,
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, Situations, wrap, makeTopic)
+import Topic(Topic, makeTopic, wrap, wrapVulNW, wrapVulSE, stdWrapNW,
+             Situations)
 
 
 -- Note that the person initiating the transfer shouldn't have had an
@@ -94,8 +95,7 @@ initiateTransfer = let
       in
         situation "Init" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.West, T.North]
+    wrapVulNW $ return sit <~ T.minorSuits
 
 
 completeTransfer :: Situations
@@ -114,8 +114,7 @@ completeTransfer = let
       in
         situation "Complete" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
+    wrapVulSE $ return sit <~ T.minorSuits
 
 
 superacceptTransfer :: Situations
@@ -137,8 +136,7 @@ superacceptTransfer = let
       in
         situation "SupAcc" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.East, T.South]
+    wrapVulSE $ return sit <~ T.minorSuits
 
 
 completeSuperacceptAKQ :: Situations
@@ -160,8 +158,7 @@ completeSuperacceptAKQ = let
       in
         situation "3NTAKQ" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ T.minorSuits
 
 
 completeSuperacceptKQJ10 :: Situations
@@ -185,8 +182,7 @@ completeSuperacceptKQJ10 = let
       in
         situation "3NTKQJ" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ T.minorSuits
 
 
 completeSuperaccept10CardFit :: Situations
@@ -208,8 +204,7 @@ completeSuperaccept10CardFit = let
       in
         situation "3NT10Fit" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ T.minorSuits
 
 
 failSuperaccept :: Situations
@@ -232,8 +227,7 @@ failSuperaccept = let
       in
         situation "SupFail" action bid explanation
   in
-    wrap $ return sit
-        <~ T.minorSuits <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ T.minorSuits
 
 
 notrumpInvite :: Situations
@@ -262,7 +256,7 @@ notrumpInvite = let
       in
         situation "NTInv" action bid explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.West]
+    stdWrapNW sit
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -7,7 +7,8 @@ import EDSL(forbid, suitLength, makePass)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, stdWrap, wrapVulDlr, Situations, makeTopic)
+import Topic(Topic, wrap, stdWrap, wrapVulDlr, Situations, makeTopic,
+             wrapVulNW, wrapVulSE, stdWrapNW, stdWrapSE)
 
 
 -- TODO: Refactor into a proper list of alertable bids, so that the solutions to
@@ -220,9 +221,7 @@ immediateGameSignoff = let
       in
         situation "gfso" action bid explanation
   in
-    wrap $ return sit <~ [B.b2D3N]
-                      <~ T.allVulnerabilities
-                      <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [B.b2D3N]
 
 
 bid2N :: Situations
@@ -239,8 +238,7 @@ bid2N = let
       in
         situation "b2N" action B.b2D2N explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities
-                      <~ [T.North, T.West]  -- We're an unpassed hand
+    stdWrapNW sit  -- We're both unpassed hands
 
 
 minimumResponse :: Situations
@@ -261,8 +259,7 @@ minimumResponse = let
       in
         situation "min" action B.b2D2N3C explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities
-                      <~ [T.North, T.West]  -- We're both unpassed hands
+    stdWrapSE sit  -- We're both unpassed hands
 
 
 maximumResponse :: Situations
@@ -284,9 +281,7 @@ maximumResponse = let
       in
         situation "max" action bid explanation
   in
-    wrap $ return sit <~ [B.b2D2N3D, B.b2D2N3H, B.b2D2N3S]
-                      <~ T.allVulnerabilities
-                      <~ [T.North, T.West]  -- We're both unpassed hands
+    wrapVulSE $ return sit <~ [B.b2D2N3D, B.b2D2N3H, B.b2D2N3S]
 
 
 gfAnyway :: Situations
@@ -310,8 +305,7 @@ gfAnyway = let
       in
         situation "reask" action B.b2D2N3C3D explanation
   in
-    wrap $ return sit <~ T.allVulnerabilities
-                      <~ [T.North, T.West]  -- We're both unpassed hands
+    stdWrapNW sit
 
 
 gfAnywayResponses :: Situations
@@ -337,9 +331,7 @@ gfAnywayResponses = let
       in
         situation "reans" action bid explanation
   in
-    wrap $ return sit <~ [B.b2D2N3C3D3H, B.b2D2N3C3D3S, B.b2D2N3C3D3N]
-                      <~ T.allVulnerabilities
-                      <~ [T.South, T.East]  -- We're both unpassed hands
+    wrapVulSE $ return sit <~ [B.b2D2N3C3D3H, B.b2D2N3C3D3S, B.b2D2N3C3D3N]
 
 
 invSignoff :: Situations
@@ -360,9 +352,7 @@ invSignoff = let
       in
         situation "invso" action bid explanation
   in
-    wrap $ return sit <~ [B.b2D2N3CP, B.b2D2N3C3H, B.b2D2N3C3S]
-                      <~ T.allVulnerabilities
-                      <~ [T.North, T.West]  -- We're both unpassed hands
+    wrapVulNW $ return sit <~ [B.b2D2N3CP, B.b2D2N3C3H, B.b2D2N3C3S]
 
 
 -- TODO:

--- a/src/Topics/StandardOpeners.hs
+++ b/src/Topics/StandardOpeners.hs
@@ -10,7 +10,7 @@ import Situation(situation, (<~))
 import qualified StandardOpenings as SO
 import Structures(currentBidder)
 import qualified Terminology as T
-import Topic(Topic, wrap, stdWrap, wrapVulDlr, Situations, makeTopic, wrap)
+import Topic(Topic, wrap, stdWrap, stdWrapSE, wrapVulDlr, Situations, makeTopic)
 
 
 -- Yes, I realize that many of these Situations lack the nuance of planning your
@@ -224,8 +224,7 @@ pass = let
   in
     -- Some people might be tempted to open light in 3rd or 4th seat, so
     -- restrict this situation to 1st or 2nd.
-    wrap $ return (situation "Pass" action makePass explanation)
-        <~ T.allVulnerabilities <~ [T.South, T.East]
+    stdWrapSE $ situation "Pass" action makePass explanation
 
 topic :: Topic
 topic = makeTopic "standard opening bids" "StdOpen" situations

--- a/src/Topics/Stayman.hs
+++ b/src/Topics/Stayman.hs
@@ -7,7 +7,8 @@ import EDSL(makePass, pointRange, suitLength, maxSuitLength, forEach)
 import Output((.+), Punct(..))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, stdWrap, wrap, wrapVulDlr, Situations, makeTopic)
+import Topic(Topic, stdWrap, wrap, wrapVulDlr, wrapVulNW, wrapVulSE,
+             Situations, makeTopic)
 
 
 garbageStayman :: Situations
@@ -173,7 +174,7 @@ noFitBalancedSlamInv = let
       in situation "SlINoF" action B.b1N2C2D4N explanation
   in
     -- We're slam invitational; we can't be a passed hand.
-    wrap $ return sit <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit
 
 
 fitInvite :: Situations
@@ -238,9 +239,8 @@ fitSlam = let
       in situation "fitSl" action responderRebid explanation
   in
     -- We're slam invitational; we can't be a passed hand.
-    wrap $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3S)
-                         , (B.b1N2C2S, B.b1N2C2S3H) ]
-                      <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3S)
+                              , (B.b1N2C2S, B.b1N2C2S3H) ]
 
 
 wrongMajorGFH :: Situations
@@ -425,10 +425,9 @@ bothMajorsUnbalancedPassed = let
       in situation "bmubup" action opener4S explanation
   in
     -- This version is only for when responder is a passed hand
-    wrap $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3C, B.b1N2C2H3C4S)
-                         , (B.b1N2C2H, B.b1N2C2H3D, B.b1N2C2H3D4S)
-                         ]
-                      <~ T.allVulnerabilities <~ [T.West, T.North]
+    wrapVulNW $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3C, B.b1N2C2H3C4S)
+                              , (B.b1N2C2H, B.b1N2C2H3D, B.b1N2C2H3D4S)
+                              ]
 
 
 bothMajorsUnbalancedUnpassed :: Situations
@@ -457,10 +456,9 @@ bothMajorsUnbalancedUnpassed = let
       in situation "bmubp" action opener4S explanation
   in
     -- This version is only for when responder is a passed hand
-    wrap $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3C, B.b1N2C2H3C3S)
-                         , (B.b1N2C2H, B.b1N2C2H3D, B.b1N2C2H3D3S)
-                         ]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1N2C2H, B.b1N2C2H3C, B.b1N2C2H3C3S)
+                              , (B.b1N2C2H, B.b1N2C2H3D, B.b1N2C2H3D3S)
+                              ]
 
 
 -- TODO eventually, but maybe in separate topics:

--- a/src/Topics/TexasTransfers.hs
+++ b/src/Topics/TexasTransfers.hs
@@ -8,7 +8,7 @@ import EDSL(makePass, makeCall, suitLength, minSuitLength, maxSuitLength,
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulNW, wrapVulSE, Situations, makeTopic)
 
 
 makeTransferSignoff :: Situations
@@ -34,8 +34,7 @@ makeTransferSignoff = let
     -- with exactly 10 HCP). It's not impossible: it happens once every couple
     -- hundred thousand hands. To speed up program execution, we focus only on
     -- the times when South is an unpassed hand.
-    wrap $ return sit <~ [B.b1N4D, B.b1N4H] <~ T.allVulnerabilities
-                      <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [B.b1N4D, B.b1N4H]
 
 
 makeTransferSlam :: Situations
@@ -57,8 +56,7 @@ makeTransferSlam = let
         in situation "SI" action bid explanation
   in
     -- Note that South cannot be a passed hand and have interest in slam.
-    wrap $ return sit <~ [B.b1N4D, B.b1N4H] <~ T.allVulnerabilities
-                      <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [B.b1N4D, B.b1N4H]
 
 
 completeTransfer :: Situations
@@ -78,8 +76,7 @@ completeTransfer = let
   in
     -- Same optimization here: don't have North make a Texas Transfer as a
     -- passed hand.
-    wrap $ return sit <~ [(B.b1N4D, B.b1N4D4H), (B.b1N4H, B.b1N4H4S)]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [(B.b1N4D, B.b1N4D4H), (B.b1N4H, B.b1N4H4S)]
 
 
 completeTransferDoubleton :: Situations
@@ -101,9 +98,8 @@ completeTransferDoubleton = let
   in
     -- Same optimization here: don't have North make a Texas Transfer as a
     -- passed hand.
-    wrap $ return sit <~ [ (B.b1N4D, B.b1N4D4H, T.Hearts)
-                         , (B.b1N4H, B.b1N4H4S, T.Spades)]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1N4D, B.b1N4D4H, T.Hearts)
+                              , (B.b1N4H, B.b1N4H4S, T.Spades)]
 
 
 -- WARNING: This situation is rare, and typically requires generating 100,000
@@ -128,9 +124,8 @@ completeTransferSuperfit = let
   in
     -- Same optimization here: don't have North make a Texas Transfer as a
     -- passed hand.
-    wrap $ return sit <~ [ (B.b1N4D, B.b1N4D4H, T.Hearts)
-                         , (B.b1N4H, B.b1N4H4S, T.Spades)]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [ (B.b1N4D, B.b1N4D4H, T.Hearts)
+                              , (B.b1N4H, B.b1N4H4S, T.Spades)]
 
 
 transferSlamInvite :: Situations
@@ -149,8 +144,7 @@ transferSlamInvite = let
             "investigate slam, and with a minimum, they'll pass."
         in situation "SInv" action bid explanation
   in
-    wrap $ return sit <~ [(B.b1N2D, T.Hearts), (B.b1N2H, T.Spades)]
-                      <~ T.allVulnerabilities <~ [T.North, T.West]
+    wrapVulNW $ return sit <~ [(B.b1N2D, T.Hearts), (B.b1N2H, T.Spades)]
 
 
 transferSlamInviteDeclined :: Situations
@@ -175,9 +169,8 @@ transferSlamInviteDeclined = let
             "invite: with a minimum hand and no extra trump length, pass."
         in situation "SInvDec" action makePass explanation
   in
-    wrap $ return sit <~ [(B.b1N2D, B.b1N2D2H, B.b1N2D2H4H, T.Hearts)
-                         ,(B.b1N2H, B.b1N2H2S, B.b1N2H2S4S, T.Spades)]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [(B.b1N2D, B.b1N2D2H, B.b1N2D2H4H, T.Hearts)
+                              ,(B.b1N2H, B.b1N2H2S, B.b1N2H2S4S, T.Spades)]
 
 
 transferSlamInviteAccepted :: Situations
@@ -205,9 +198,8 @@ transferSlamInviteAccepted = let
             "invistigate slam, your preferred bid might differ)."
         in situation "SInvAcc" action (makeCall $ T.Bid 4 T.Notrump) explanation
   in
-    wrap $ return sit <~ [(B.b1N2D, B.b1N2D2H, B.b1N2D2H4H, T.Hearts)
-                         ,(B.b1N2H, B.b1N2H2S, B.b1N2H2S4S, T.Spades)]
-                      <~ T.allVulnerabilities <~ [T.South, T.East]
+    wrapVulSE $ return sit <~ [(B.b1N2D, B.b1N2D2H, B.b1N2D2H4H, T.Hearts)
+                              ,(B.b1N2H, B.b1N2H2S, B.b1N2H2S4S, T.Spades)]
 
 
 -- TODO: More situations:


### PR DESCRIPTION
This was coming up often enough I should make some wrappers around it. I still suspect I've got the wrong data structures around this: there shouldn't be a need for `stdWrap` (and its NW and SE variations) in addition to `wrapVulDlr` (and its NW and SE variations). but that's a problem for another day.

Also a problem for another day: changing the conditions under which SMP hands get opened (which can be a point or two lighter than the rule of 20).