### PR TITLE
better handling of opening strength in SMP

### DIFF
--- a/src/Bids/StandardModernPrecision/BasicBids.hs
+++ b/src/Bids/StandardModernPrecision/BasicBids.hs
@@ -20,7 +20,8 @@ import Action(Action, constrain)
 import CommonBids(cannotPreempt)
 import EDSL(forbid, pointRange, suitLength, minSuitLength, hasTopN,
             balancedHand, makeCall, makeAlertableCall, makePass, alternatives,
-            minLoserCount, maxLoserCount, forEach, forbidAll)
+            minLoserCount, maxLoserCount, forEach, forbidAll, longerThan,
+            atLeastAsLong)
 import Output(Punct(..), (.+))
 import Structures(currentBidder)
 import qualified Terminology as T
@@ -84,6 +85,11 @@ b1M suit = do
     -- If you're a maximum with a 6-card minor and 5-card major, open the minor.
     forEach T.minorSuits (\minor -> forbid (
         pointRange 14 15 >> minSuitLength minor 6 >> suitLength suit 5))
+    -- TODO: would you reverse with 5-5 in the majors and a maximum?
+    -- TODO: these should use `when`, but it doesn't seem to exist yet. Maybe
+    -- upgrade base?
+    if suit == T.Hearts then T.Hearts `longerThan` T.Spades else return ()
+    if suit == T.Spades then T.Spades `atLeastAsLong` T.Hearts else return ()
     makeCall $ T.Bid 1 suit
 
 

--- a/src/Bids/StandardModernPrecision/BasicBids.hs
+++ b/src/Bids/StandardModernPrecision/BasicBids.hs
@@ -133,5 +133,7 @@ setOpener opener = do
 -- unexported helper
 _canOpen :: Action
 _canOpen = alternatives [ pointRange 11 40
-                       , pointRange 10 40 >> maxLoserCount 7
-                       ]
+                        , do forbid balancedHand
+                             pointRange 10 40
+                             maxLoserCount 7
+                        ]

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -60,7 +60,7 @@ module Bids.StandardModernPrecision.OneClub(
 ) where
 
 import Action(Action, constrain)
-import Bids.StandardModernPrecision.BasicBids(b1C, firstSeatOpener, oppsPass)
+import Bids.StandardModernPrecision.BasicBids(b1C, oppsPass)
 import EDSL(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
             balancedHand, makeCall, makeAlertableCall, alternatives, longerThan,
             atLeastAsLong, forEach, forbidAll, maxLoserCount, minLoserCount)
@@ -221,7 +221,6 @@ bP1C2S = do
 -----------
 startOfMafia :: Action
 startOfMafia = do
-    firstSeatOpener
     b1C
     oppsPass
     b1C1D

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -63,7 +63,7 @@ import Action(Action, constrain)
 import Bids.StandardModernPrecision.BasicBids(b1C, firstSeatOpener, oppsPass)
 import EDSL(forbid, pointRange, suitLength, minSuitLength, maxSuitLength,
             balancedHand, makeCall, makeAlertableCall, alternatives, longerThan,
-            atLeastAsLong, forEach, forbidAll)
+            atLeastAsLong, forEach, forbidAll, maxLoserCount, minLoserCount)
 import Output((.+), Punct(..))
 import qualified Terminology as T
 
@@ -333,7 +333,7 @@ b1C1D1H2H :: Action
 b1C1D1H2H = do
     minSuitLength T.Hearts 4
     maxSuitLength T.Hearts 5
-    pointRange 0 4
+    alternatives [pointRange 0 4, pointRange 0 5 >> minLoserCount 11]
     makeCall $ T.Bid 2 T.Hearts
 
 
@@ -342,6 +342,7 @@ b1C1D1H3H = do
     minSuitLength T.Hearts 4
     pointRange 5 7
     forEach T.allSuits (`minSuitLength` 2)
+    maxLoserCount 10
     makeCall $ T.Bid 3 T.Hearts
 
 
@@ -352,6 +353,7 @@ b1C1D1H2N = do
     -- The 2N bid is for hands with a singleton or void, so forbid the
     -- semibalanced response.
     forbid b1C1D1H3H
+    maxLoserCount 10
     makeAlertableCall (T.Bid 2 T.Notrump)
                       ("5" .+ NDash .+ "7 HCP, undisclosed splinter for hearts")
 
@@ -400,7 +402,7 @@ b1C1D1S2S :: Action
 b1C1D1S2S = do
     minSuitLength T.Spades 4
     maxSuitLength T.Spades 5
-    pointRange 0 4
+    alternatives [pointRange 0 4, pointRange 0 5 >> minLoserCount 11]
     makeCall $ T.Bid 2 T.Spades
 
 
@@ -409,6 +411,7 @@ b1C1D1S3S = do
     minSuitLength T.Spades 4
     pointRange 5 7
     forEach T.allSuits (`minSuitLength` 2)
+    maxLoserCount 10
     makeCall $ T.Bid 3 T.Spades
 
 
@@ -419,6 +422,7 @@ b1C1D1S2N = do
     -- The 2N bid is for hands with a singleton or void, so forbid the
     -- semibalanced response.
     forbid b1C1D1S3S
+    maxLoserCount 10
     makeAlertableCall (T.Bid 2 T.Notrump)
                       ("5" .+ NDash .+ "7 HCP, undisclosed splinter for spades")
 

--- a/src/Topics/StandardModernPrecision/Lampe.hs
+++ b/src/Topics/StandardModernPrecision/Lampe.hs
@@ -1,32 +1,31 @@
 module Topics.StandardModernPrecision.Lampe(topic) where
 
-import Bids.StandardModernPrecision.BasicBids(
-    firstSeatOpener, smpWrapN, smpWrapS)
+import Bids.StandardModernPrecision.BasicBids(setOpener)
 import qualified Bids.StandardModernPrecision.Lampe as B
 import CommonBids(noInterference)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulNW, wrapVulSE, Situations, makeTopic)
 
 
 twoClubs :: Situations
 twoClubs = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         B.b1D
         noInterference T.Diamonds
     explanation =
         "With at least invitational strength and a minor, start with an " .+
         "artificial " .+ T.Bid 2 T.Clubs .+ "."
   in
-    smpWrapN . return $ situation "2C" action B.b1D2C explanation
+    wrapVulNW . return $ situation "2C" action B.b1D2C explanation
 
 
 twoClubsUnbal :: Situations
 twoClubsUnbal = let
     action = do
-        firstSeatOpener
+        setOpener T.South
         B.b1D
         noInterference T.Diamonds
         B.b1D2C
@@ -35,13 +34,13 @@ twoClubsUnbal = let
         "With an unbalanced minimum, rebid an artificial " .+
         T.Bid 2 T.Diamonds .+ "."
   in
-    smpWrapS . return $ situation "2CUnbal" action B.b1D2C2D explanation
+    wrapVulSE . return $ situation "2CUnbal" action B.b1D2C2D explanation
 
 
 twoClubsBal :: Situations
 twoClubsBal = let
     action = do
-        firstSeatOpener
+        setOpener T.South
         B.b1D
         noInterference T.Diamonds
         B.b1D2C
@@ -50,14 +49,14 @@ twoClubsBal = let
         "With a balanced minimum, rebid an artificial " .+
         T.Bid 2 T.Hearts .+ "."
   in
-    smpWrapS . return $ situation "2CBal" action B.b1D2C2H explanation
+    wrapVulSE . return $ situation "2CBal" action B.b1D2C2H explanation
 
 
 twoClubsSS :: Situations
 twoClubsSS = let
     sit answer = let
         action = do
-            firstSeatOpener
+            setOpener T.South
             B.b1D
             noInterference T.Diamonds
             B.b1D2C
@@ -72,10 +71,8 @@ twoClubsSS = let
         situation "2CSS" action answer explanation
   in
     -- For us to bid a forcing 1N, we must be an unpassed hand.
-    wrap $ return sit
+    wrapVulSE $ return sit
         <~ [B.b1D2C2S, B.b1D2C2N, B.b1D2C3C, B.b1D2C3D, B.b1D2C3H, B.b1D2C3S]
-        <~ T.allVulnerabilities
-        <~ [T.South]
 
 
 -- TODO:
@@ -89,14 +86,14 @@ twoClubsSS = let
 twoDiamonds :: Situations
 twoDiamonds = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         B.b1D
         noInterference T.Diamonds
     explanation =
         "With both majors and less than game forcing strength, make a " .+
         "Reverse-Flannery-like " .+ T.Bid 2 T.Diamonds .+ " bid."
   in
-    smpWrapN . return $ situation "2D" action B.b1D2D explanation
+    wrapVulNW . return $ situation "2D" action B.b1D2D explanation
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/Mafia.hs
+++ b/src/Topics/StandardModernPrecision/Mafia.hs
@@ -1,19 +1,20 @@
 module Topics.StandardModernPrecision.Mafia(topic) where
 
-import Bids.StandardModernPrecision.BasicBids(smpWrapS)
+import Bids.StandardModernPrecision.BasicBids(setOpener)
 import qualified Bids.StandardModernPrecision.OneClub as B
 import EDSL(forbid, minSuitLength, suitLength, balancedHand, equalLength,
             longerThan)
 import Output(Punct(..), (.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulSE, Situations, makeTopic)
 
 
 notrump :: Situations
 notrump = let
     sit bid = let
         action = do
+            setOpener T.South
             B.startOfMafia
         explanation =
             "With a balanced hand, rebid notrump to show your point range.\
@@ -22,13 +23,14 @@ notrump = let
       in
         situation "xN" action bid explanation
   in
-    smpWrapS $ return sit <~ [B.b1C1D1N, B.b1C1D2N]
+    wrapVulSE $ return sit <~ [B.b1C1D1N, B.b1C1D2N]
 
 
 oneMajor :: Situations
 oneMajor = let
     sit bid = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
         explanation =
@@ -37,13 +39,14 @@ oneMajor = let
       in
         situation "1M" action bid explanation
   in
-    smpWrapS $ return sit <~ [B.b1C1D1H, B.b1C1D1S]
+    wrapVulSE $ return sit <~ [B.b1C1D1H, B.b1C1D1S]
 
 
 oneMajorMinor :: Situations
 oneMajorMinor = let
     sit (majorSuit, bid) minorSuit = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
             minSuitLength minorSuit 5
@@ -55,7 +58,7 @@ oneMajorMinor = let
       in
         situation "1Mm" action bid explanation
   in
-    smpWrapS $ return sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
+    wrapVulSE $ return sit <~ [(T.Hearts, B.b1C1D1H), (T.Spades, B.b1C1D1S)]
                           <~ T.minorSuits
 
 
@@ -63,6 +66,7 @@ twoMinorSingle :: Situations
 twoMinorSingle = let
     sit (minorSuit, bid) = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
             minSuitLength minorSuit 6
@@ -72,13 +76,14 @@ twoMinorSingle = let
       in
         situation "2m" action bid explanation
   in
-    smpWrapS $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    wrapVulSE $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 twoMinorMinors :: Situations
 twoMinorMinors = let
     sit (minorSuit, bid) = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
             suitLength minorSuit 5
@@ -91,13 +96,14 @@ twoMinorMinors = let
       in
         situation "2mm" action bid explanation
   in
-    smpWrapS $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
+    wrapVulSE $ return sit <~ [(T.Clubs, B.b1C1D2C), (T.Diamonds, B.b1C1D2D)]
 
 
 equalMinors :: Situations
 equalMinors = let
     sit = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
             T.Clubs `equalLength` T.Diamonds
@@ -109,13 +115,14 @@ equalMinors = let
       in
         situation "2me" action B.b1C1D2D explanation
   in
-    smpWrapS $ return sit
+    wrapVulSE $ return sit
 
 
 bothMajorsLongSpades :: Situations
 bothMajorsLongSpades = let
     sit = let
         action = do
+            setOpener T.South
             B.startOfMafia
             forbid balancedHand
             minSuitLength T.Hearts 4
@@ -127,13 +134,14 @@ bothMajorsLongSpades = let
       in
         situation "2MS" action B.b1C1D1S explanation
   in
-    smpWrapS $ return sit
+    wrapVulSE $ return sit
 
 
 jumpBid :: Situations
 jumpBid = let
     sit bid = let
         action = do
+            setOpener T.South
             B.startOfMafia
         explanation =
             "With an unbalanced hand that is strong enough to\
@@ -143,7 +151,7 @@ jumpBid = let
       in
         situation "J1" action bid explanation
   in
-    smpWrapS $ return sit <~ [B.b1C1D2H, B.b1C1D2S, B.b1C1D3C, B.b1C1D3D]
+    wrapVulSE $ return sit <~ [B.b1C1D2H, B.b1C1D2S, B.b1C1D3C, B.b1C1D3D]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/MafiaResponses.hs
+++ b/src/Topics/StandardModernPrecision/MafiaResponses.hs
@@ -1,13 +1,13 @@
 module Topics.StandardModernPrecision.MafiaResponses(topic) where
 
-import Bids.StandardModernPrecision.BasicBids(oppsPass, smpWrapN)
+import Bids.StandardModernPrecision.BasicBids(oppsPass, setOpener)
 import qualified Bids.StandardModernPrecision.OneClub as B
 import Action(Action)
 import EDSL(suitLength, maxSuitLength)
 import Output((.+), Punct(..))
 import Situation(Situation, situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulNW, Situations, makeTopic)
 
 
 minSupport :: Situations
@@ -17,6 +17,7 @@ minSupport = let
     sit :: (Action, Action) -> T.Vulnerability -> T.Direction -> Situation
     sit (openerBid, responderBid) = let
         action = do
+            setOpener T.North
             B.startOfMafia
             openerBid
             oppsPass
@@ -27,8 +28,8 @@ minSupport = let
       in
         situation "2M" action responderBid explanation
   in
-    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2H)
-                             , (B.b1C1D1S, B.b1C1D1S2S) ]
+    wrapVulNW $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2H)
+                              , (B.b1C1D1S, B.b1C1D1S2S) ]
 
 
 maxSupportSemibalanced :: Situations
@@ -38,6 +39,7 @@ maxSupportSemibalanced = let
     sit :: (Action, Action) -> T.Vulnerability -> T.Direction -> Situation
     sit (openerBid, responderBid) = let
         action = do
+            setOpener T.North
             B.startOfMafia
             openerBid
             oppsPass
@@ -49,8 +51,8 @@ maxSupportSemibalanced = let
       in
         situation "3MB" action responderBid explanation
   in
-    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H3H)
-                             , (B.b1C1D1S, B.b1C1D1S3S) ]
+    wrapVulNW $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H3H)
+                              , (B.b1C1D1S, B.b1C1D1S3S) ]
 
 
 maxSupportUnbalanced :: Situations
@@ -60,6 +62,7 @@ maxSupportUnbalanced = let
     sit :: (Action, Action) -> T.Vulnerability -> T.Direction -> Situation
     sit (openerBid, responderBid) = let
         action = do
+            setOpener T.North
             B.startOfMafia
             openerBid
             oppsPass
@@ -76,14 +79,15 @@ maxSupportUnbalanced = let
       in
         situation "3MV" action responderBid explanation
   in
-    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
-                             , (B.b1C1D1S, B.b1C1D1S2N) ]
+    wrapVulNW $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2N)
+                              , (B.b1C1D1S, B.b1C1D1S2N) ]
 
 
 brakesHearts :: Situations
 brakesHearts = let
     sit = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1H
             oppsPass
@@ -99,13 +103,14 @@ brakesHearts = let
       in
         situation "1NH" action B.b1C1D1H1N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 brakesSpades :: Situations
 brakesSpades = let
     sit = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1S
             oppsPass
@@ -122,13 +127,14 @@ brakesSpades = let
       in
         situation "1NS" action B.b1C1D1S1N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 brakesSpadesHearts :: Situations
 brakesSpadesHearts = let
     sit = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1S
             oppsPass
@@ -148,13 +154,14 @@ brakesSpadesHearts = let
       in
         situation "1NSH" action B.b1C1D1S1N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 otherMajorHearts :: Situations
 otherMajorHearts = let
     sit = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1H
             oppsPass
@@ -166,13 +173,14 @@ otherMajorHearts = let
       in
         situation "1S" action B.b1C1D1H1S explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 otherMajorSpades :: Situations
 otherMajorSpades = let
     sit = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1S
             oppsPass
@@ -187,7 +195,7 @@ otherMajorSpades = let
       in
         situation "2H" action B.b1C1D1S2H explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 threeCardSupport :: Situations
@@ -195,6 +203,7 @@ threeCardSupport = let
     sit :: (Action, Action) -> T.Vulnerability -> T.Direction -> Situation
     sit (openerBid, responderBid) = let
         action = do
+            setOpener T.North
             B.startOfMafia
             openerBid
             oppsPass
@@ -208,14 +217,15 @@ threeCardSupport = let
       in
         situation "2D" action responderBid explanation
   in
-    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
-                           , (B.b1C1D1S, B.b1C1D1S2D) ]
+    wrapVulNW $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2D)
+                              , (B.b1C1D1S, B.b1C1D1S2D) ]
 
 
 threeCardSupportHearts :: Situations
 threeCardSupportHearts = let
     sit  = let
         action = do
+            setOpener T.North
             B.startOfMafia
             B.b1C1D1S
             oppsPass
@@ -227,7 +237,7 @@ threeCardSupportHearts = let
       in
         situation "2D" action B.b1C1D1S2D explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 maxNoMajors :: Situations
@@ -235,6 +245,7 @@ maxNoMajors = let
     sit :: (Action, Action) -> T.Vulnerability -> T.Direction -> Situation
     sit (openerBid, responderBid) = let
         action = do
+            setOpener T.North
             B.startOfMafia
             openerBid
             oppsPass
@@ -249,8 +260,8 @@ maxNoMajors = let
       in
         situation "2C" action responderBid explanation
   in
-    smpWrapN $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
-                             , (B.b1C1D1S, B.b1C1D1S2C) ]
+    wrapVulNW $ return sit <~ [ (B.b1C1D1H, B.b1C1D1H2C)
+                              , (B.b1C1D1S, B.b1C1D1S2C) ]
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/OneClubResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneClubResponses.hs
@@ -2,34 +2,32 @@ module Topics.StandardModernPrecision.OneClubResponses(
   topic
 , topicExtras) where
 
-import Bids.StandardModernPrecision.BasicBids(
-    firstSeatOpener, oppsPass, b1C, smpWrapN, smpWrapS)
+import Bids.StandardModernPrecision.BasicBids(setOpener, oppsPass, b1C)
 import qualified Bids.StandardModernPrecision.OneClub as B
-import CommonBids(cannotPreempt)
-import EDSL(forbid, maxSuitLength, makePass, pointRange, forEach)
+import EDSL(maxSuitLength, pointRange, forEach)
 import Output(Punct(..), (.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulNW, wrapVulSE, Situations, makeTopic)
 
 
 oneDiamond :: Situations
 oneDiamond = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
         "When game might not be possible opposite a random 17 HCP, start\
       \ with " .+ T.Bid 1 T.Diamonds .+ ". This initiates MaFiA."
   in
-    smpWrapN . return $ situation "1D" action B.b1C1D explanation
+    wrapVulNW . return $ situation "1D" action B.b1C1D explanation
 
 
 oneHeart :: Situations
 oneHeart = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -38,13 +36,13 @@ oneHeart = let
       \ Subsequent bids are natural 5-card suits (and later 4-card suits), not\
       \ MaFiA."
   in
-    smpWrapN . return $ situation "1H" action B.b1C1H explanation
+    wrapVulNW . return $ situation "1H" action B.b1C1H explanation
 
 
 oneHeartNoSpades :: Situations
 oneHeartNoSpades = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -53,13 +51,13 @@ oneHeartNoSpades = let
       \ this kind of hand. Partner's rebid will be a natural 5-card suit, not\
       \ MaFiA."
   in
-    smpWrapN . return $ situation "1Hns" action B.b1C1Hnos explanation
+    wrapVulNW . return $ situation "1Hns" action B.b1C1Hnos explanation
 
 
 oneNotrump :: Situations
 oneNotrump = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -67,13 +65,13 @@ oneNotrump = let
       \ hand with no 5-card suit. Bid a natural " .+ T.Bid 1 T.Notrump .+ ",\
       \ and we'll go from there. Stayman is on, but transfers are not."
   in
-    smpWrapN . return $ situation "1N" action B.b1C1N explanation
+    wrapVulNW . return $ situation "1N" action B.b1C1N explanation
 
 
 oneNotrumpAlt :: Situations
 oneNotrumpAlt = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -85,7 +83,7 @@ oneNotrumpAlt = let
       \ Compared to the naive approach, this never wastes extra bidding room\
       \ and often saves some for control bids after we've found a fit."
   in
-    smpWrapN . return $ situation "1Nalt" action B.b1C1Nalt explanation
+    wrapVulNW . return $ situation "1Nalt" action B.b1C1Nalt explanation
 
 
 slamSingleSuit :: Situations
@@ -101,7 +99,7 @@ slamSingleSuitModified :: Situations
         level = if strain == T.Spades then 1 else 2
         bid = finalAction strain
         action = do
-            firstSeatOpener
+            setOpener T.North
             b1C
             oppsPass
             forEach (filter (/= strain) T.allSuits) (`maxSuitLength` 4)
@@ -114,14 +112,14 @@ slamSingleSuitModified :: Situations
       in
         situation "Slam" action bid explanation
   in
-    ( smpWrapN $ return sit <~ T.allSuits
-    , smpWrapN $ return sit <~ [T.Clubs, T.Diamonds])
+    ( wrapVulNW $ return sit <~ T.allSuits
+    , wrapVulNW $ return sit <~ [T.Clubs, T.Diamonds])
 
 
 twoHeartsBalanced :: Situations
 twoHeartsBalanced = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -135,13 +133,13 @@ twoHeartsBalanced = let
         T.Bid 3 T.Spades .+ " to show that (which should be\
       \ surprising enough for you to recognize/remember)."
   in
-    smpWrapN . return $ situation "2HAlt" action B.b1C2Halt explanation
+    wrapVulNW . return $ situation "2HAlt" action B.b1C2Halt explanation
 
 
 twoNotrumpBalanced :: Situations
 twoNotrumpBalanced = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -153,7 +151,7 @@ twoNotrumpBalanced = let
       \ bid naturally. They're captain of the auction: they'll know whether to\
       \ sign off in game or investigate slam."
   in
-    smpWrapN . return $ situation "2NAlt" action B.b1C2Nalt explanation
+    wrapVulNW . return $ situation "2NAlt" action B.b1C2Nalt explanation
 
 
 oneSpadeGF :: Situations
@@ -171,19 +169,20 @@ oneSpadeGF = let
       \ partner you're interested in slam, too."
     sit (explanation, minHcp, maxHcp) = let
         action = do
-            firstSeatOpener
+            setOpener T.North
             b1C
             oppsPass
             pointRange minHcp maxHcp
       in
         situation "1Sgf" action B.b1C1Sgf explanation
   in
-    smpWrapN $ return sit <~ [(explanationMin, 8, 11), (explanationMax, 12, 40)]
+    wrapVulNW $ return sit <~ [ (explanationMin, 8, 11)
+                              , (explanationMax, 12, 40) ]
 
 twoSpades :: Situations
 twoSpades = let
     action = do
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -196,7 +195,7 @@ twoSpades = let
         T.Bid 4 T.Diamonds .+ "/RKC to tell us how high to go and\
       \ what suit is trump."
   in
-    smpWrapN . return $ situation "2S" action B.b1C2S explanation
+    wrapVulNW . return $ situation "2S" action B.b1C2S explanation
 
 
 passGameSingleSuit :: Situations
@@ -211,12 +210,7 @@ passGameSingleSuit = let
         level = if strain `elem` T.majorSuits then 1 else 2
         bid = finalAction strain
         action = do
-            forbid firstSeatOpener
-            cannotPreempt
-            makePass
-            forbid firstSeatOpener
-            oppsPass
-            firstSeatOpener
+            setOpener T.North
             b1C
             oppsPass
             forEach (filter (/= strain) T.allSuits) (`maxSuitLength` 4)
@@ -229,18 +223,13 @@ passGameSingleSuit = let
       in
         situation "PG" action bid explanation
   in
-    smpWrapS $ return sit <~ T.allSuits
+    wrapVulSE $ return sit <~ T.allSuits
 
 
 passOneNotrump :: Situations
 passOneNotrump = let
     action = do
-        forbid firstSeatOpener
-        cannotPreempt
-        makePass
-        forbid firstSeatOpener
-        oppsPass
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -250,18 +239,13 @@ passOneNotrump = let
       \ we'll go from there. Stayman is on, but transfers are off (so the\
       \ stronger hand will be declarer more often)."
   in
-    smpWrapS . return $ situation "P1N" action B.bP1C1N explanation
+    wrapVulSE . return $ situation "P1N" action B.bP1C1N explanation
 
 
 passTwoSpades :: Situations
 passTwoSpades = let
     action = do
-        forbid firstSeatOpener
-        cannotPreempt
-        makePass
-        forbid firstSeatOpener
-        oppsPass
-        firstSeatOpener
+        setOpener T.North
         b1C
         oppsPass
     explanation =
@@ -275,7 +259,7 @@ passTwoSpades = let
         T.Bid 4 T.Diamonds .+ "/RKC to indicate how high to go\
       \ and which suit is trump."
   in
-    smpWrapS . return $ situation "P2S" action B.bP1C2S explanation
+    wrapVulSE . return $ situation "P2S" action B.bP1C2S explanation
 
 
 -- TODO: figure out how two-suited hands show slam interest. Which suit do you

--- a/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
+++ b/src/Topics/StandardModernPrecision/OneDiamondResponses.hs
@@ -1,18 +1,19 @@
 module Topics.StandardModernPrecision.OneDiamondResponses(topic) where
 
-import Bids.StandardModernPrecision.BasicBids(oppsPass, b1D, smpWrapN)
+import Bids.StandardModernPrecision.BasicBids(oppsPass, b1D, setOpener)
 import qualified Bids.StandardModernPrecision.OneDiamond as B
 import EDSL(maxSuitLength, minSuitLength, pointRange, alternatives)
 import Output(Punct(..), (.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, wrapVulNW, Situations, makeTopic)
 
 
 oneMajor :: Situations
 oneMajor = let
     sit bid = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -21,13 +22,14 @@ oneMajor = let
       in
         situation "1M" action bid explanation
   in
-    smpWrapN $ return sit <~ [B.b1D1H, B.b1D1S]
+    wrapVulNW $ return sit <~ [B.b1D1H, B.b1D1S]
 
 
 twoMinor6M :: Situations
 twoMinor6M = let
     sit (minor, bid) major = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
             minSuitLength minor 6
@@ -41,14 +43,15 @@ twoMinor6M = let
       in
         situation "6m4M" action bid explanation
   in
-    smpWrapN $ return sit <~ [(T.Clubs, B.b1D2C), (T.Diamonds, B.b1D2D)]
-                          <~ [T.Hearts, T.Spades]
+    wrapVulNW $ return sit <~ [(T.Clubs, B.b1D2C), (T.Diamonds, B.b1D2D)]
+                           <~ [T.Hearts, T.Spades]
 
 
 twoMinorLongInv :: Situations
 twoMinorLongInv = let
     sit (minor, bid) = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
             minSuitLength minor 6
@@ -62,13 +65,14 @@ twoMinorLongInv = let
       in
         situation "6mw" action bid explanation
   in
-    smpWrapN $ return sit <~ [(T.Clubs, B.b1D2C), (T.Diamonds, B.b1D2D)]
+    wrapVulNW $ return sit <~ [(T.Clubs, B.b1D2C), (T.Diamonds, B.b1D2D)]
 
 
 twoMinorBothInv :: Situations
 twoMinorBothInv = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
             minSuitLength T.Clubs 4
@@ -87,13 +91,14 @@ twoMinorBothInv = let
       in
         situation "9m" action B.b1D2D explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 reverseFlannery :: Situations
 reverseFlannery = let
     sit (bid, isInvite) = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -109,13 +114,14 @@ reverseFlannery = let
       in
         situation "RevFl" action bid explanation
   in
-    smpWrapN $ return sit <~ [(B.b1D2H, False), (B.b1D2S, True)]
+    wrapVulNW $ return sit <~ [(B.b1D2H, False), (B.b1D2S, True)]
 
 
 weakMinors54 :: Situations
 weakMinors54 = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -128,13 +134,14 @@ weakMinors54 = let
       in
         situation "54min" action B.b1D3C explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 weakMinors55 :: Situations
 weakMinors55 = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -146,13 +153,14 @@ weakMinors55 = let
       in
         situation "55min" action B.b1D4C explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 notrump1 :: Situations
 notrump1 = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -163,13 +171,14 @@ notrump1 = let
       in
         situation "1N" action B.b1D1N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 notrump2 :: Situations
 notrump2 = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -189,13 +198,14 @@ notrump2 = let
       in
         situation "2N" action B.b1D2N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 notrump3 :: Situations
 notrump3 = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -207,13 +217,14 @@ notrump3 = let
       in
         situation "3N" action B.b1D3N explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 invertedMinors :: Situations
 invertedMinors = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -224,13 +235,14 @@ invertedMinors = let
       in
         situation "3d" action B.b1D3D explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 
 
 preempt3M :: Situations
 preempt3M = let
     sit bid = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -241,7 +253,7 @@ preempt3M = let
       in
         situation "3M" action bid explanation
   in
-    smpWrapN $ return sit <~ [B.b1D3H, B.b1D3S]
+    wrapVulNW $ return sit <~ [B.b1D3H, B.b1D3S]
 
 
 -- TODO: uncomment this and get it right when you're more confident of the
@@ -251,6 +263,7 @@ preempt4D :: Situations
 preempt4D = let
     sit = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -262,7 +275,7 @@ preempt4D = let
       in
         situation "4D" action B.b1D4D explanation
   in
-    smpWrapN $ return sit
+    wrapVulNW $ return sit
 -}
 
 
@@ -270,6 +283,7 @@ majorGame :: Situations
 majorGame = let
     sit bid = let
         action = do
+            setOpener T.North
             b1D
             oppsPass
         explanation =
@@ -282,7 +296,7 @@ majorGame = let
       in
         situation "4M" action bid explanation
   in
-    smpWrapN $ return sit <~ [B.b1D4H, B.b1D4S]
+    wrapVulNW $ return sit <~ [B.b1D4H, B.b1D4S]
 
 
 

--- a/src/Topics/StandardModernPrecision/OpeningBids.hs
+++ b/src/Topics/StandardModernPrecision/OpeningBids.hs
@@ -4,36 +4,36 @@ import qualified Bids.StandardModernPrecision.BasicBids as B
 import Output((.+), Punct(..))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, Situations, makeTopic)
+import Topic(Topic, wrap, stdWrap, wrapVulDlr, Situations, makeTopic)
 
 
 oneClub :: Situations
 oneClub = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "With 16 or more points (17 or more when balanced), open a strong " .+
         T.Bid 1 T.Clubs .+ ". This is the hallmark of SMP."
   in
-    B.smpWrapS . return $ situation "1C" action B.b1C explanation
+    stdWrap $ situation "1C" action B.b1C explanation
 
 
 oneDiamond :: Situations
 oneDiamond = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "With opening strength but the wrong strength/shape for any other\
       \ opening bid, start with " .+ T.Bid 1 T.Diamonds .+ "."
   in
-    B.smpWrapS . return $ situation "1D" action B.b1D explanation
+    stdWrap $ situation "1D" action B.b1D explanation
 
 
 oneMajor :: Situations
 oneMajor = let
     sit suit = let
         action = do
-            B.firstSeatOpener
+            B.setOpener T.South
             -- TODO: What if you're 5-5?
         explanation =
             "With opening strength but not enough for a strong " .+
@@ -43,53 +43,53 @@ oneMajor = let
         situation "1M" action (B.b1M suit) explanation
   in
     -- TODO: figure out some syntactic sugar for this, too
-    B.smpWrapS $ return sit <~ T.majorSuits
+    wrapVulDlr $ return sit <~ T.majorSuits
 
 
 oneNotrump :: Situations
 oneNotrump = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "With a balanced hand and 14" .+ NDash .+ "16 HCP, open " .+
         T.Bid 1 T.Notrump .+ "."
   in
-    B.smpWrapS . return $ situation "1N" action B.b1N explanation
+    stdWrap $ situation "1N" action B.b1N explanation
 
 
 twoClubs :: Situations
 twoClubs = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "With a 6-card club suit, no 5-card major, an opening hand but not a\
        \ hand strong enough to open " .+ T.Bid 1 T.Clubs .+ ",\
        \ open " .+ T.Bid 2 T.Clubs .+ "."
   in
-    B.smpWrapS . return $ situation "2C" action B.b2C explanation
+    stdWrap $ situation "2C" action B.b2C explanation
 
 
 twoDiamonds :: Situations
 twoDiamonds = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "The " .+ T.Bid 2 T.Diamonds .+ " hand is that 3-suited\
        \ hand without diamonds, which can be thought of as a 14-card hand with\
        \ 4415 shape but missing any single card."
   in
-    B.smpWrapS . return $ situation "2D" action B.b2D explanation
+    stdWrap $ situation "2D" action B.b2D explanation
 
 
 twoNotrump :: Situations
 twoNotrump = let
     action = do
-        B.firstSeatOpener
+        B.setOpener T.South
     explanation =
         "With a balanced hand and 19 or 20 HCP, open " .+
         T.Bid 2 T.Notrump .+ "."
   in
-    B.smpWrapS . return $ situation "2N" action B.b2N explanation
+    stdWrap $ situation "2N" action B.b2N explanation
 
 
 topic :: Topic

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -1,8 +1,9 @@
 module Topics.StandardModernPrecision.TwoDiamondOpeners(topic) where
 
 import Action(Action)
+import Bids.StandardModernPrecision.BasicBids(setOpener)
 import qualified Bids.StandardModernPrecision.TwoDiamonds as B
-import CommonBids(setOpener, takeoutDouble)
+import CommonBids(takeoutDouble)
 import EDSL(forbid, suitLength, makePass)
 import Output((.+))
 import Situation(situation, (<~))

--- a/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
+++ b/src/Topics/StandardModernPrecision/TwoDiamondOpeners.hs
@@ -12,10 +12,6 @@ import Topic(Topic, wrap, stdWrap, wrapVulDlr, Situations, makeTopic,
              wrapVulNW, wrapVulSE, stdWrapNW, stdWrapSE)
 
 
--- TODO: Refactor into a proper list of alertable bids, so that the solutions to
--- the situations can be self-alerted, too.
-
-
 -- When trying to sign off with less than invitational strength, a new suit
 -- being nonforcing is alertable only if you're an unpassed hand, so we have
 -- different bids depending on who the dealer is.


### PR DESCRIPTION
In SMP, we open all 11-HCP hands and unbalanced 7-loser hands with 10 HCP. In the SMP topics, we decide whether to open the bidding as though all 4 players are using those same criteria. and now we have the same interface as the 2/1 topics. 

I haven't noticed any problems yet, but I'll keep checking for a while...