### PR TITLE
more frontend tweaks

### DIFF
--- a/src/Topics/JacobyTransfers.hs
+++ b/src/Topics/JacobyTransfers.hs
@@ -367,13 +367,8 @@ topic = makeTopic "Jacoby transfers"  "JacTrans" $
          , completeTransfer
          , completeTransferShort
          -- rare situations
-         , wrap [ majors55inv
-                , majors55gf
-                , majors55inv2
-                , majors55gf2
-                , noFlatSuperaccept
-                ]
+         , wrap [majors55inv, majors55gf, majors55inv2, majors55gf2]
          , rebidMinor
-         , superaccept
+         , wrap [superaccept, noFlatSuperaccept]
          , singleSuitedInvite
          ]

--- a/static/index.html
+++ b/static/index.html
@@ -26,7 +26,7 @@
             <table border=0 style="table-layout: fixed;">
               <tr>
                 <td style="vertical-align: top;">
-                  <table style="table-layout: fixed; width: 30em;">
+                  <table style="table-layout: fixed; width: 30em; padding: 1ex;">
                     <tr>
                       <td class="hand_size" style="width: 33.3%; height: 10ex;">
                       </td>

--- a/static/index.html
+++ b/static/index.html
@@ -14,25 +14,25 @@
       </p>
       <table border=0>
         <tr>
-          <td width="400em" style="vertical-align: top;">
+          <td style="vertical-align: top; width: 20em;">
             <span id="topic_list"></span>
           </td>
           <td style="vertical-align: top; border-left: 1px solid darkgrey;">
             <table border=0 style="table-layout: fixed;" height="500ex">
               <tr>
                 <td style="vertical-align: top;">
-                  <table width="600em" style="table-layout: fixed">
+                  <table style="table-layout: fixed; width: 30em;">
                     <tr>
-                      <td class="hand_size" width="33.3%" height="125ex">
+                      <td class="hand_size" style="width: 33.3%; height: 10ex;">
                       </td>
-                      <td class="hand" width="33.3%">
+                      <td class="hand" style="width: 33.3%;">
                         <span id="north_hand"></span>
                       </td>
-                      <td class="hand_size" width="33.3%">
+                      <td class="hand_size" style="width: 33.3%;">
                       </td>
                     </tr>
                     <tr>
-                      <td class="hand" height="125ex">
+                      <td class="hand" style="height: 10ex;">
                         <span id="west_hand"></span>
                       </td>
                       <td>
@@ -49,7 +49,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td class="hand_size" height="125ex">
+                      <td class="hand_size" style="height: 10ex;">
                         <div style="float: right; padding: 2ex; width: 10ex;">
                           Dealer: <span id="dealer"></span><br/>
                           Vul: <span id="vulnerability"></span>
@@ -74,7 +74,7 @@
                     </table>
                   </center>
                 </td>
-                <td id="explanation" width="400em" style="vertical-align: top;">
+                <td id="explanation">
                 </td>
               </tr>
             </table>

--- a/static/index.html
+++ b/static/index.html
@@ -50,7 +50,7 @@
                     </tr>
                     <tr>
                       <td class="hand_size" height="125ex">
-                        <div style="float: right; padding: 2ex;">
+                        <div style="float: right; padding: 2ex; width: 10ex;">
                           Dealer: <span id="dealer"></span><br/>
                           Vul: <span id="vulnerability"></span>
                         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -28,7 +28,7 @@
                 <td style="vertical-align: top;">
                   <table style="table-layout: fixed; width: 30em; padding: 1ex;">
                     <tr>
-                      <td class="hand_size" style="width: 33.3%; height: 10ex;">
+                      <td class="hand_size" style="width: 33.3%;">
                       </td>
                       <td class="hand" style="width: 33.3%;">
                         <span id="north_hand"></span>
@@ -37,7 +37,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td class="hand" style="height: 10ex;">
+                      <td class="hand">
                         <span id="west_hand"></span>
                       </td>
                       <td>
@@ -54,7 +54,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <td class="hand_size" style="height: 10ex;">
+                      <td class="hand_size">
                         <div style="float: right; padding: 2ex; width: 10ex;">
                           Dealer: <span id="dealer"></span><br/>
                           Vul: <span id="vulnerability"></span>

--- a/static/index.html
+++ b/static/index.html
@@ -17,10 +17,12 @@
           <td style="vertical-align: top; width: 20em;">
             <span id="topic_list"></span>
             <br/>
-            <hr/>&nbsp;&nbsp;&nbsp;
-            <a href="https://github.com/penguinland/bridge_practice">
-              source code
-            </a>
+            <hr/>
+            <center>
+              <a href="https://github.com/penguinland/bridge_practice">
+                source code
+              </a>
+            </center>
           </td>
           <td style="vertical-align: top; border-left: 1px solid darkgrey;">
             <table border=0 style="table-layout: fixed;">

--- a/static/index.html
+++ b/static/index.html
@@ -16,6 +16,11 @@
         <tr>
           <td style="vertical-align: top; width: 20em;">
             <span id="topic_list"></span>
+            <br/>
+            <hr/>&nbsp;&nbsp;&nbsp;
+            <a href="https://github.com/penguinland/bridge_practice">
+              source code
+            </a>
           </td>
           <td style="vertical-align: top; border-left: 1px solid darkgrey;">
             <table border=0 style="table-layout: fixed;">
@@ -78,11 +83,6 @@
                 </td>
               </tr>
             </table>
-            <br/>
-            <hr/>&nbsp;&nbsp;&nbsp;
-            <a href="https://github.com/penguinland/bridge_practice">
-              source code
-            </a>
           </td>
         </tr>
       </table>

--- a/static/index.html
+++ b/static/index.html
@@ -28,14 +28,14 @@
             <table border=0 style="table-layout: fixed;">
               <tr>
                 <td style="vertical-align: top;">
-                  <table style="table-layout: fixed; width: 30em; padding: 1ex;">
+                  <table style="table-layout: fixed; padding: 1ex;">
                     <tr>
-                      <td id="top_col1" class="hand_size" style="width: 33.3%;">
+                      <td id="top_col1" class="hand_size">
                       </td>
-                      <td id="top_col2" class="hand" style="width: 33.3%;">
+                      <td id="top_col2" class="hand">
                         <span id="north_hand"></span>
                       </td>
-                      <td id="top_col3" class="hand_size" style="width: 33.3%;">
+                      <td id="top_col3" class="hand_size">
                       </td>
                     </tr>
                     <tr>

--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,7 @@
             <span id="topic_list"></span>
           </td>
           <td style="vertical-align: top; border-left: 1px solid darkgrey;">
-            <table border=0 style="table-layout: fixed;" height="500ex">
+            <table border=0 style="table-layout: fixed;">
               <tr>
                 <td style="vertical-align: top;">
                   <table style="table-layout: fixed; width: 30em;">

--- a/static/index.html
+++ b/static/index.html
@@ -30,12 +30,12 @@
                 <td style="vertical-align: top;">
                   <table style="table-layout: fixed; width: 30em; padding: 1ex;">
                     <tr>
-                      <td class="hand_size" style="width: 33.3%;">
+                      <td id="top_col1" class="hand_size" style="width: 33.3%;">
                       </td>
-                      <td class="hand" style="width: 33.3%;">
+                      <td id="top_col2" class="hand" style="width: 33.3%;">
                         <span id="north_hand"></span>
                       </td>
-                      <td class="hand_size" style="width: 33.3%;">
+                      <td id="top_col3" class="hand_size" style="width: 33.3%;">
                       </td>
                     </tr>
                     <tr>
@@ -57,7 +57,7 @@
                     </tr>
                     <tr>
                       <td class="hand_size">
-                        <div style="float: right; padding: 2ex;">
+                        <div id="dlrvul" style="float: right; padding: 2ex;">
                           Dealer: <span id="dealer"></span><br/>
                           Vul: <span id="vulnerability"></span>
                         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
       </p>
       <table border=0>
         <tr>
-          <td style="vertical-align: top; width: 20em;">
+          <td style="vertical-align: top; width: 20em; max-width: 33%;">
             <span id="topic_list"></span>
             <br/>
             <hr/>
@@ -57,7 +57,7 @@
                     </tr>
                     <tr>
                       <td class="hand_size">
-                        <div style="float: right; padding: 2ex; width: 10ex;">
+                        <div style="float: right; padding: 2ex;">
                           Dealer: <span id="dealer"></span><br/>
                           Vul: <span id="vulnerability"></span>
                         </div>

--- a/static/index.js
+++ b/static/index.js
@@ -52,6 +52,12 @@ getTopics().then(topics => {
         topic_section.appendChild(newline);
     })
 
+    setWidth("dlrvul", "Dealer: W  ");
+    // I don't know the widths of the suit symbols; substitute a W.
+    setWidth("top_col1", "W  A K Q J 10 9 8 7");
+    setWidth("top_col2", "W  A K Q J 10 9 8 7");
+    setWidth("top_col3", "W  A K Q J 10 9 8 7");
+
     displayProblem();
 })
 
@@ -180,4 +186,21 @@ function displaySolution() {
     dbg = document.createElement("p")
     dbg.innerHTML = "debug string: " + current_problem.debug_string;
     expl.appendChild(dbg);
+}
+
+function setWidth(elemId, text) {
+    elem = document.getElementById(elemId);
+
+    // Solution for computing width is inspired by
+    // https://stackoverflow.com/a/21015393
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    // Solution for getting default font is inspired by
+    // https://stackoverflow.com/a/7444724
+    context.font = window.getComputedStyle(elem, null).font;
+    const metrics = context.measureText(text);
+
+    elem.style.width = metrics.width + "px";
+    elem.style.minWidth = metrics.width + "px";
+    console.log(metrics.width);
 }

--- a/static/style.css
+++ b/static/style.css
@@ -18,5 +18,7 @@ td.hand_size {
 }
 
 #explanation {
-    width: 17em;
+    width: 15em;
+    min-width: 15em;
+    padding: 0.5ex;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -9,8 +9,12 @@ td.hand_size {
     padding: 10px;
 }
 
-.topic{
+.topic {
     margin: 1ex;
     text-indent: -2ex;
     padding-left: 2ex;
+}
+
+#explanation {
+    width: 17em;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -2,11 +2,13 @@
     background-color: #E8E8E8;
     border-radius: 10px;
     padding: 10px;
+    height: 10ex;
 }
 
 /* The padding needs to match .hand, or the tables are have uneven sizes. */
 td.hand_size {
     padding: 10px;
+    height: 10ex;
 }
 
 .topic {


### PR DESCRIPTION
Frontend development is such a pain! The bigger issues here have been:
- Make the explanation have a fixed width. On phones, the total width is wider than the screen, meaning you need to scroll sideways to see the whole explanation. By making the width a constant, moving to the next problem does not shrink the width of the explanation column back to the width of the "show answer" button, so that when you do show the answer, you don't need to scroll sideways yet again.
- Make the hands have a fixed width that can support 8-card suits. No more guessing what the right width is: it's enough to display an 8-card suit, period.
- Move the link to the source code to below the topic list. That way it doesn't change position as the auction gets longer or shorter, which I found distracting.
- Set the width of the "dealer/vul" section to a constant, long enough to accommodate the longest string within. That way, the positions of the words "dealer" and "vul" don't change every time the dealer/vulnerability change. Again, it's a small thing but it had been bugging me.