### PR TITLE
put an ordering on the HTML topic list, independent of their IDs

### DIFF
--- a/server/Main.hs
+++ b/server/Main.hs
@@ -2,9 +2,8 @@
 module Main where
 
 import Control.Monad.Trans(liftIO)
-import Data.Aeson(object, (.=))
+import Data.Aeson(Value, object, (.=))
 import Data.Aeson.Key(fromString)
-import Data.Aeson.Types(Value)
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.List.Utils(join, split)

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -4,6 +4,7 @@ module Main where
 import Control.Monad.Trans(liftIO)
 import Data.Aeson(Value, object, (.=))
 import Data.Aeson.Key(fromString)
+import Data.Containers.ListUtils(nubOrd)
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.List.Utils(join, split)
@@ -107,6 +108,13 @@ data MyAppState = IoRng (IORef StdGen)
 
 main :: IO ()
 main = do
+    -- First, assert that all IDs for topics are unique: otherwise, we're gonna
+    -- have really subtle bugs that will be hard to figure out.
+    -- TODO: consider making this a compile-time assertion instead, possibly via
+    -- https://stackoverflow.com/a/6654903
+    if ((length topicList) /= (length . nubOrd . map fst $ topicList))
+        then error "duplicate topic indices!?"
+        else return ()
     rng <- getStdGen
     ref <- newIORef rng
     spockCfg <- defaultSpockCfg EmptySession PCNoDatabase (IoRng ref)

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -2,6 +2,7 @@
 module Main where
 
 import Control.Monad.Trans(liftIO)
+import Data.Bifunctor(second)
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.List.Utils(join, split)
@@ -38,34 +39,33 @@ import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDiamondO
 --import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 
 
-topicList :: [Topic]
-topicList = [ StandardOpeners.topic
-            , MajorSuitRaises.topic
-            , ForcingOneNotrump.topic
-            , JacobyTransfers.topic
-            , Stayman.topic
-            , TexasTransfers.topic
-            , Meckwell.topic
-            , Jacoby2NT.topic
-            , SmpOpenings.topic
-            , Smp1CResponses.topic
-            , Smp1CResponses.topicExtras
-            , Mafia.topic
-            , MafiaResponses.topic
-            , Smp1DResponses.topic
-            , Lampe.topic
-            , TwoDiamondOpeners.topic
+-- The list is the order to display topics on the website. The int is a unique
+-- ID for the topic when requesting a situation. That way, you can add new
+-- topics to the middle of the list without messing up anyone using the website.
+topicList :: [(Int, Topic)]
+topicList = [ (11, StandardOpeners.topic)
+            , (12, MajorSuitRaises.topic)
+            , (13, ForcingOneNotrump.topic)
+            , (14, JacobyTransfers.topic)
+            , (15, Stayman.topic)
+            , (16, TexasTransfers.topic)
+            , (17, Meckwell.topic)
+            , (18, Jacoby2NT.topic)
+            , (19, SmpOpenings.topic)
+            , (20, Smp1CResponses.topic)
+            , (21, Smp1CResponses.topicExtras)
+            , (22, Mafia.topic)
+            , (23, MafiaResponses.topic)
+            , (24, Smp1DResponses.topic)
+            , (25, Lampe.topic)
+            , (26, TwoDiamondOpeners.topic)
             ]
 
 topics :: Map Int Topic
-topics = fromList . enumerate $ topicList
-  where
-    -- I'm surprised this isn't defined in a popular, standard location.
-    enumerate :: [a] -> [(Int, a)]
-    enumerate = zipWith (,) [0..]
+topics = fromList topicList
 
-topicNames :: Map Int String
-topicNames = fmap (toHtml . topicName) topics
+topicNames :: [(Int, String)]
+topicNames = map (second $ toHtml . topicName) topicList
 
 
 getTopic :: Int -> Either Int Topic

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -2,7 +2,9 @@
 module Main where
 
 import Control.Monad.Trans(liftIO)
-import Data.Bifunctor(second)
+import Data.Aeson(object, (.=))
+import Data.Aeson.Key(fromString)
+import Data.Aeson.Types(Value)
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.List.Utils(join, split)
@@ -64,8 +66,13 @@ topicList = [ (10, StandardOpeners.topic)
 topics :: Map Int Topic
 topics = fromList topicList
 
-topicNames :: [(Int, String)]
-topicNames = map (second $ toHtml . topicName) topicList
+topicNames :: [Value]
+topicNames = map toObject topicList
+  where
+    toObject (id, topic) =
+        object [ fromString "index" .= id
+               , fromString "name"  .= (toHtml . topicName $ topic)
+               ]
 
 
 getTopic :: Int -> Either Int Topic

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -43,22 +43,22 @@ import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDiamondO
 -- ID for the topic when requesting a situation. That way, you can add new
 -- topics to the middle of the list without messing up anyone using the website.
 topicList :: [(Int, Topic)]
-topicList = [ (11, StandardOpeners.topic)
-            , (12, MajorSuitRaises.topic)
-            , (13, ForcingOneNotrump.topic)
-            , (14, JacobyTransfers.topic)
-            , (15, Stayman.topic)
-            , (16, TexasTransfers.topic)
-            , (17, Meckwell.topic)
-            , (18, Jacoby2NT.topic)
-            , (19, SmpOpenings.topic)
-            , (20, Smp1CResponses.topic)
-            , (21, Smp1CResponses.topicExtras)
-            , (22, Mafia.topic)
-            , (23, MafiaResponses.topic)
-            , (24, Smp1DResponses.topic)
-            , (25, Lampe.topic)
-            , (26, TwoDiamondOpeners.topic)
+topicList = [ (10, StandardOpeners.topic)
+            , (11, MajorSuitRaises.topic)
+            , (12, ForcingOneNotrump.topic)
+            , (13, JacobyTransfers.topic)
+            , (14, Stayman.topic)
+            , (15, TexasTransfers.topic)
+            , (16, Meckwell.topic)
+            , (17, Jacoby2NT.topic)
+            , (50, SmpOpenings.topic)
+            , (51, Smp1CResponses.topic)
+            , (52, Smp1CResponses.topicExtras)
+            , (53, Mafia.topic)
+            , (54, MafiaResponses.topic)
+            , (55, Smp1DResponses.topic)
+            , (70, Lampe.topic)
+            , (56, TwoDiamondOpeners.topic)
             ]
 
 topics :: Map Int Topic

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -39,7 +39,6 @@ import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDiamondO
 
 -- I don't think I ever finished making these topics...
 --import qualified Topics.MinorTransfersScott as MinorTransfers
---import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 
 
 -- The list is the order to display topics on the website. The int is a unique
@@ -64,18 +63,21 @@ topicList = [ (10, StandardOpeners.topic)
             , (56, TwoDiamondOpeners.topic)
             ]
 
--- Make a way to assert that all IDs for topics are unique: otherwise, we're
--- gonna have really subtle bugs that will be hard to figure out.
+
+-- If topic indices aren't unique, we're gonna have really subtle bugs that will
+-- be hard to figure out.
 -- TODO: consider making this a compile-time assertion instead, possibly via
 -- https://stackoverflow.com/a/6654903
-assertUniqueIndices :: IO()
-assertUniqueIndices = let
+assertUniqueTopicIndices :: IO()
+assertUniqueTopicIndices = let
     indices = map fst topicList
   in
     when (indices /= nubOrd indices) (error "duplicate topic indices!?")
 
+
 topics :: Map Int Topic
 topics = fromList topicList
+
 
 topicNames :: [Value]
 topicNames = map toObject topicList
@@ -119,7 +121,7 @@ data MyAppState = IoRng (IORef StdGen)
 
 main :: IO ()
 main = do
-    assertUniqueIndices
+    assertUniqueTopicIndices
     rng <- getStdGen
     ref <- newIORef rng
     spockCfg <- defaultSpockCfg EmptySession PCNoDatabase (IoRng ref)

--- a/static/index.js
+++ b/static/index.js
@@ -27,15 +27,17 @@ async function getSituation() {
 // Create checkbox options for each topic the server supports.
 getTopics().then(topics => {
     const topic_section = document.getElementById("topic_list")
-    Object.entries(topics).forEach(([index, name]) => {
+    var count = 0;
+    topics.forEach(([index, name]) => {
         const tag_name = "topic_" + index;
         const checkbox = document.createElement("input");
         checkbox.type  = "checkbox"
         checkbox.id    = tag_name;
         checkbox.name  = "topics";
         checkbox.value = index;
-        if (index < 4) {
+        if (count < 4) {
             checkbox.checked = true; // Start off with a couple defaults
+            count++;
         }
 
         const topic_name = document.createElement("span");

--- a/static/index.js
+++ b/static/index.js
@@ -28,20 +28,20 @@ async function getSituation() {
 getTopics().then(topics => {
     const topic_section = document.getElementById("topic_list")
     var count = 0;
-    topics.forEach(([index, name]) => {
-        const tag_name = "topic_" + index;
+    topics.forEach(topic => {
+        const tag_name = "topic_" + topic.index;
         const checkbox = document.createElement("input");
         checkbox.type  = "checkbox"
         checkbox.id    = tag_name;
         checkbox.name  = "topics";
-        checkbox.value = index;
+        checkbox.value = topic.index;
         if (count < 4) {
             checkbox.checked = true; // Start off with a couple defaults
             count++;
         }
 
         const topic_name = document.createElement("span");
-        topic_name.innerHTML = name;
+        topic_name.innerHTML = topic.name;
 
         // Make the text of the checkbox clickable, too.
         const label = document.createElement("label");


### PR DESCRIPTION
That way, you can add new topics into the middle of the list without shifting the IDs of the later ones, and that way people who haven't refreshed the page since you updated the server can continue using things properly.