### PR TITLE
Bugfixes for J2NT

### DIFF
--- a/make_pdf/Main.hs
+++ b/make_pdf/Main.hs
@@ -44,5 +44,5 @@ main = let
   in do
     -- outputLatex returns a copy of the contents of the file it wrote, but we
     -- ignore that.
-    _ <- outputLatex 100 topics "test" (mkStdGen 2)
+    _ <- outputLatex 100 topics "test" (mkStdGen 0)
     return ()

--- a/make_pdf/Main.hs
+++ b/make_pdf/Main.hs
@@ -44,5 +44,5 @@ main = let
   in do
     -- outputLatex returns a copy of the contents of the file it wrote, but we
     -- ignore that.
-    _ <- outputLatex 100 topics "test" (mkStdGen 0)
+    _ <- outputLatex 100 topics "test" (mkStdGen 2)
     return ()

--- a/src/Bids/Jacoby2NT.hs
+++ b/src/Bids/Jacoby2NT.hs
@@ -51,8 +51,8 @@ module Bids.Jacoby2NT(
 import Action(Action)
 import Bids.StandardOpenings(b1H, b1S)
 import EDSL(minSuitLength, maxSuitLength, makeCall, makeAlertableCall,
-            pointRange, soundHolding, minLoserCount, maxLoserCount, forbidAll,
-            shorterThan, atMostAsLong, forEach, hasControl, forbid)
+            pointRange, soundHolding, maxLoserCount, forbid, forbidAll,
+            shorterThan, atMostAsLong, forEach, hasControl)
 import Output((.+))
 import qualified Terminology as T
 
@@ -212,42 +212,42 @@ shapelyRebidsS_ = [b1S2N4C, b1S2N4D, b1S2N4H, b1S2N3C, b1S2N3D, b1S2N3H]
 b1H2N4H :: Action
 b1H2N4H = do
     forbidAll shapelyRebidsH_
-    pointRange 0 13
+    pointRange 0 14
     makeCall $ T.Bid 4 T.Hearts
 
 
 b1H2N3N :: Action
 b1H2N3N = do
     forbidAll shapelyRebidsH_
-    pointRange 14 15
+    pointRange 15 16
     makeCall $ T.Bid 3 T.Notrump
 
 
 b1H2N3H :: Action
 b1H2N3H = do
     forbidAll shapelyRebidsH_
-    pointRange 16 40
+    pointRange 17 40
     makeCall $ T.Bid 3 T.Hearts
 
 
 b1S2N4S :: Action
 b1S2N4S = do
     forbidAll shapelyRebidsS_
-    pointRange 0 13
+    pointRange 0 14
     makeCall $ T.Bid 4 T.Spades
 
 
 b1S2N3N :: Action
 b1S2N3N = do
     forbidAll shapelyRebidsS_
-    pointRange 14 15
+    pointRange 15 16
     makeCall $ T.Bid 3 T.Notrump
 
 
 b1S2N3S :: Action
 b1S2N3S = do
     forbidAll shapelyRebidsS_
-    pointRange 16 40
+    pointRange 17 40
     makeCall $ T.Bid 3 T.Spades
 
 
@@ -255,25 +255,25 @@ b1S2N3S = do
 
 b1H2N4HP :: Action
 b1H2N4HP = do
-    minLoserCount 6
+    pointRange 0 16
     makeCall T.Pass
 
 
 b1S2N4SP :: Action
 b1S2N4SP = do
-    minLoserCount 6
+    pointRange 0 16
     makeCall T.Pass
 
 
 b1H2N3N4H :: Action
 b1H2N3N4H = do
-    minLoserCount 7
+    pointRange 0 14
     makeCall $ T.Bid 4 T.Hearts
 
 
 b1S2N3N4S :: Action
 b1S2N3N4S = do
-    minLoserCount 7
+    pointRange 0 14
     makeCall $ T.Bid 4 T.Spades
 
 -- Slam investigations

--- a/src/Bids/Jacoby2NT.hs
+++ b/src/Bids/Jacoby2NT.hs
@@ -364,11 +364,13 @@ b1H2N3H4D = do
     makeCall $ T.Bid 4 T.Diamonds
 
 
+-- WARNING: it is exceedingly rare to not have control in any side suit! Maybe
+-- don't use this, because it doesn't come up often enough.
 b1H2N3H4H :: Action
 b1H2N3H4H = do
     forbid b1H2N3H3S
     forbid b1H2N3H4C
-    forbid b1H2N3H4H
+    forbid b1H2N3H4D
     makeCall $ T.Bid 4 T.Hearts
 
 
@@ -393,6 +395,8 @@ b1S2N3S4H = do
     makeCall $ T.Bid 4 T.Hearts
 
 
+-- WARNING: it is exceedingly rare to not have control in any side suit! Maybe
+-- don't use this, because it doesn't come up often enough.
 b1S2N3S4S :: Action
 b1S2N3S4S = do
     forbid b1S2N3S4C

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -3,8 +3,10 @@ module ProblemSet(
 , outputLatex
 ) where
 
+import Control.Monad(when)
 import Control.Monad.Trans.State.Strict(runState, get)
 import Data.List.Utils(join, replace)
+import System.IO(hFlush, stdout)
 import System.Random(StdGen)
 
 import Output(toLatex)
@@ -30,6 +32,7 @@ generate n topics g = let
         instantiate ref situation
     (sitInst, g') = runState makeInst g
   in do
+    when (n `mod` 10 == 0) (putStr "." >> hFlush stdout)
     maybeSit <- sitInst
     case maybeSit of
         Nothing -> generate n topics g'  -- Try again

--- a/src/Topics/Jacoby2NT.hs
+++ b/src/Topics/Jacoby2NT.hs
@@ -270,14 +270,17 @@ semibalMaxSlam = let
   in
     -- Partner must be an unpassed hand to be game-forcing.
     wrapVulNW $ return sit
+        -- Although it's possible to have no controls and want to rebid 4M, it
+        -- is exceedingly unlikely. Skip those situations because they're so
+        -- rare.
         <~ [ (B.b1H, B.b1H2N, B.b1H2N3H, B.b1H2N3H3S,  T.Hearts)
            , (B.b1H, B.b1H2N, B.b1H2N3H, B.b1H2N3H4C,  T.Hearts)
            , (B.b1H, B.b1H2N, B.b1H2N3H, B.b1H2N3H4D,  T.Hearts)
-           , (B.b1H, B.b1H2N, B.b1H2N3H, B.b1H2N3H4H,  T.Hearts)
+           --, (B.b1H, B.b1H2N, B.b1H2N3H, B.b1H2N3H4H,  T.Hearts)
            , (B.b1S, B.b1S2N, B.b1S2N3S, B.b1S2N3S4C,  T.Spades)
            , (B.b1S, B.b1S2N, B.b1S2N3S, B.b1S2N3S4D,  T.Spades)
            , (B.b1S, B.b1S2N, B.b1S2N3S, B.b1S2N3S4H,  T.Spades)
-           , (B.b1S, B.b1S2N, B.b1S2N3S, B.b1S2N3S4S,  T.Spades)
+           --, (B.b1S, B.b1S2N, B.b1S2N3S, B.b1S2N3S4S,  T.Spades)
            ]
 
 


### PR DESCRIPTION
- Go back to HCPs instead of loser count when deciding whether to sign off after 4M/3N
- Bump the point count when opener rebids 3N
- Avoid an infinite loop/space leak due to a typo
- Remove the situations when you ought to control bid but don't have control in any suit; they're exceptionally rare.
- When generating lots of situations, print out a dot every 10, so it's obvious we're making progress.