### PR TITLE
cache the next problem, for speedier UX

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -67,7 +67,7 @@
                       </td>
                       <td style="vertical-align: center;">
                         <center>
-                          <button onclick="displayProblem()">
+                          <button onclick="nextProblem()">
                             Next Problem
                           </button>
                         </center>


### PR DESCRIPTION
- At the very start, get 2 problems: one to display, and the next problem to display after that.
- When it's time to go to the next problem, if the topic list hasn't changed and we have a cached problem, show that, and only get a new problem if the list has changed or we don't have a cached problem. Then, get another new problem to display next time.