### PR TITLE
Make a topic for 4441 hands after an SMP 1C opening

### DIFF
--- a/make_pdf/Main.hs
+++ b/make_pdf/Main.hs
@@ -14,6 +14,7 @@ import qualified Topics.StandardModernPrecision.Lampe as Lampe
 import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as Smp2DOpen
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
+import qualified Topics.StandardModernPrecision.TripleFourOne as TripleFourOne
 import qualified Topics.MajorSuitRaises as MajorSuitRaises
 import qualified Topics.Meckwell as Meckwell
 import qualified Topics.Jacoby2NT as Jacoby2NT
@@ -40,8 +41,9 @@ main = let
               , Meckwell.topic
               , Jacoby2NT.topic
               , Lampe.topic
+              , TripleFourOne.topic
               ]
-    topics = [Smp2DOpen.topic]
+    topics = [TripleFourOne.topic]
   in do
     -- outputLatex returns a copy of the contents of the file it wrote, but we
     -- ignore that.

--- a/server/SupportedTopics.hs
+++ b/server/SupportedTopics.hs
@@ -33,6 +33,7 @@ import qualified Topics.StandardModernPrecision.Mafia as Mafia
 import qualified Topics.StandardModernPrecision.MafiaResponses as MafiaResponses
 import qualified Topics.StandardModernPrecision.Lampe as Lampe
 import qualified Topics.StandardModernPrecision.TwoDiamondOpeners as TwoDiamondOpeners
+import qualified Topics.StandardModernPrecision.TripleFourOne as TripleFourOne
 
 -- I don't think I ever finished making these topics...
 --import qualified Topics.MinorTransfersScott as MinorTransfers
@@ -59,6 +60,7 @@ topicList = [ (10, True,  StandardOpeners.topic)
             , (55, False, Smp1DResponses.topic)
             , (70, False, Lampe.topic)
             , (56, False, TwoDiamondOpeners.topic)
+            , (57, False, TripleFourOne.topic)
             ]
 
 

--- a/server/SupportedTopics.hs
+++ b/server/SupportedTopics.hs
@@ -57,10 +57,10 @@ topicList = [ (10, True,  StandardOpeners.topic)
             , (52, False, Smp1CResponses.topicExtras)
             , (53, False, Mafia.topic)
             , (54, False, MafiaResponses.topic)
+            , (57, False, TripleFourOne.topic)
             , (55, False, Smp1DResponses.topic)
             , (70, False, Lampe.topic)
             , (56, False, TwoDiamondOpeners.topic)
-            , (57, False, TripleFourOne.topic)
             ]
 
 

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -219,8 +219,8 @@ bP1C1N = do
 bP1C2S :: Action
 bP1C2S = do
     _gameForcing
-    constrain "triple41" ["shape(", ", 4441 + 4414 + 4144 + 1444)"]
-    makeAlertableCall (T.Bid 2 T.Spades) "Game forcing, any 4441 shape"
+    tripleFourOneShape
+    makeAlertableCall (T.Bid 2 T.Spades) "game forcing, any 4441 shape"
 
 
 -----------

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -51,6 +51,7 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C1S3C
   , b1C1N
   , b1C1Nalt
+  , b1C1Nalt3C
   , b1C2C
   , b1C2C3D
   , b1C2D
@@ -66,6 +67,7 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C2S2N3S
   , b1C2Nalt
   , bP1C1H
+  , bP1C1H2S
   , bP1C1S
   , bP1C1N
   , bP1C2C
@@ -608,28 +610,28 @@ b1C1H1S3C :: Action
 b1C1H1S3C = do
     tripleFourOneShape
     suitLength T.Spades 1
-    makeAlertableCall (T.Bid 3 T.Clubs) "1444 shape with singleton spade"
+    makeAlertableCall (T.Bid 3 T.Clubs) "1444 shape with a singleton spade"
 
 
 b1C1H2C3D :: Action
 b1C1H2C3D = do
     tripleFourOneShape
     suitLength T.Clubs 1
-    makeAlertableCall (T.Bid 3 T.Diamonds) "4441 shape with singleton club"
+    makeAlertableCall (T.Bid 3 T.Diamonds) "4441 shape with a singleton club"
 
 
 b1C1H2D3H :: Action
 b1C1H2D3H = do
     tripleFourOneShape
     suitLength T.Diamonds 1
-    makeAlertableCall (T.Bid 3 T.Hearts) "4414 shape with singleton diamond"
+    makeAlertableCall (T.Bid 3 T.Hearts) "4414 shape with a singleton diamond"
 
 
 b1C1H2H3S :: Action
 b1C1H2H3S = do
     tripleFourOneShape
     suitLength T.Hearts 1
-    makeAlertableCall (T.Bid 3 T.Spades) "4144 shape with singleton heart"
+    makeAlertableCall (T.Bid 3 T.Spades) "4144 shape with a singleton heart"
 
 
 b1C1S3C :: Action
@@ -641,8 +643,17 @@ b1C2C3D = b1C1H2C3D
 b1C2D3H :: Action
 b1C2D3H = b1C1H2D3H
 
--- TODO: if you're using the alternative responses, how do you show a 4144 shape
--- over 1C-1N? Presumably it's 1C-1N-3C. Is it worth having a topic just for
--- this one change?
 b1C2H3S :: Action
 b1C2H3S = b1C1H2H3S
+
+b1C1Nalt3C :: Action
+b1C1Nalt3C = do
+    tripleFourOneShape
+    suitLength T.Hearts 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "4144 shape with a singleton heart"
+
+bP1C1H2S :: Action
+bP1C1H2S = do
+    tripleFourOneShape
+    suitLength T.Hearts 1
+    makeAlertableCall (T.Bid 2 T.Spades) "4144 shape with a singleton heart"

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -563,19 +563,19 @@ b1C1H2S2N3C = do
 b1C1H2S2N3D :: Action
 b1C1H2S2N3D = do
     suitLength T.Diamonds 1
-    makeAlertableCall (T.Bid 3 T.Clubs) "singleton diamond"
+    makeAlertableCall (T.Bid 3 T.Diamonds) "singleton diamond"
 
 
 b1C1H2S2N3H :: Action
 b1C1H2S2N3H = do
     suitLength T.Hearts 1
-    makeAlertableCall (T.Bid 3 T.Clubs) "singleton heart"
+    makeAlertableCall (T.Bid 3 T.Hearts) "singleton heart"
 
 
 b1C1H2S2N3S :: Action
 b1C1H2S2N3S = do
     suitLength T.Spades 1
-    makeAlertableCall (T.Bid 3 T.Clubs) "singleton spade"
+    makeAlertableCall (T.Bid 3 T.Spades) "singleton spade"
 
 
 b1C2S2N :: Action

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -30,10 +30,14 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C1H
   , b1C1Hnos
   , b1C1H1S
+  , b1C1H1S3C
   , b1C1H1N
   , b1C1H2C
+  , b1C1H2C3D
   , b1C1H2D
+  , b1C1H2D3H
   , b1C1H2H
+  , b1C1H2H3S
   , b1C1H2S
   , b1C1H2S2N
   , b1C1H2S2N3C
@@ -44,12 +48,16 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C1H3N
   , b1C1S
   , b1C1Sgf
+  , b1C1S3C
   , b1C1N
   , b1C1Nalt
   , b1C2C
+  , b1C2C3D
   , b1C2D
+  , b1C2D3H
   , b1C2H
   , b1C2Halt
+  , b1C2H3S
   , b1C2S
   , b1C2S2N
   , b1C2S2N3C
@@ -592,3 +600,49 @@ b1C2S2N3H = b1C1H2S2N3H
 
 b1C2S2N3S :: Action
 b1C2S2N3S = b1C1H2S2N3S
+
+
+-- Cheapest jump-shift showing 4441 with a singleton in partner's suit
+
+b1C1H1S3C :: Action
+b1C1H1S3C = do
+    tripleFourOneShape
+    suitLength T.Spades 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "1444 shape with singleton spade"
+
+
+b1C1H2C3D :: Action
+b1C1H2C3D = do
+    tripleFourOneShape
+    suitLength T.Clubs 1
+    makeAlertableCall (T.Bid 3 T.Diamonds) "4441 shape with singleton club"
+
+
+b1C1H2D3H :: Action
+b1C1H2D3H = do
+    tripleFourOneShape
+    suitLength T.Diamonds 1
+    makeAlertableCall (T.Bid 3 T.Hearts) "4414 shape with singleton diamond"
+
+
+b1C1H2H3S :: Action
+b1C1H2H3S = do
+    tripleFourOneShape
+    suitLength T.Hearts 1
+    makeAlertableCall (T.Bid 3 T.Spades) "4144 shape with singleton heart"
+
+
+b1C1S3C :: Action
+b1C1S3C = b1C1H1S3C
+
+b1C2C3D :: Action
+b1C2C3D = b1C1H2C3D
+
+b1C2D3H :: Action
+b1C2D3H = b1C1H2D3H
+
+-- TODO: if you're using the alternative responses, how do you show a 4144 shape
+-- over 1C-1N? Presumably it's 1C-1N-3C. Is it worth having a topic just for
+-- this one change?
+b1C2H3S :: Action
+b1C2H3S = b1C1H2H3S

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -1,9 +1,47 @@
 module Bids.StandardModernPrecision.OneClub(
     b1C  -- Copied from BasicBids
-  -- Responses to 1C
   , b1C1D
+  , startOfMafia
+  , b1C1D1H
+  , b1C1D1H1S
+  , b1C1D1H1N
+  , b1C1D1H2C
+  , b1C1D1H2D
+  , b1C1D1H2H
+  , b1C1D1H2N
+  , b1C1D1H3H
+  -- TODO: jumps and double jumps in MaFiA
+  , b1C1D1S
+  , b1C1D1S1N
+  , b1C1D1S2C
+  , b1C1D1S2D
+  , b1C1D1S2H
+  , b1C1D1S2S
+  , b1C1D1S2N
+  , b1C1D1S3S
+  , b1C1D1N
+  , b1C1D2C
+  , b1C1D2D
+  , b1C1D2H
+  , b1C1D2S
+  , b1C1D2N
+  , b1C1D3C
+  , b1C1D3D
   , b1C1H
   , b1C1Hnos
+  , b1C1H1S
+  , b1C1H1N
+  , b1C1H2C
+  , b1C1H2D
+  , b1C1H2H
+  , b1C1H2S
+  , b1C1H2S2N
+  , b1C1H2S2N3C
+  , b1C1H2S2N3D
+  , b1C1H2S2N3H
+  , b1C1H2S2N3S
+  , b1C1H2N
+  , b1C1H3N
   , b1C1S
   , b1C1Sgf
   , b1C1N
@@ -25,47 +63,6 @@ module Bids.StandardModernPrecision.OneClub(
   , bP1C2C
   , bP1C2D
   , bP1C2S  -- Note that the auction P-1C-2H cannot occur!
-  -- rebids after 1C-1D
-  , startOfMafia
-  , b1C1D1H
-  , b1C1D1S
-  , b1C1D1N
-  , b1C1D2C
-  , b1C1D2D
-  , b1C1D2H
-  , b1C1D2S
-  , b1C1D2N
-  , b1C1D3C
-  , b1C1D3D
-  -- rebids after 1C-1D-1M
-  , b1C1D1H1S
-  , b1C1D1H1N
-  , b1C1D1H2C
-  , b1C1D1H2D
-  , b1C1D1H2H
-  , b1C1D1H2N
-  , b1C1D1H3H
-  , b1C1D1S1N
-  , b1C1D1S2C
-  , b1C1D1S2D
-  , b1C1D1S2H
-  , b1C1D1S2S
-  , b1C1D1S2N
-  , b1C1D1S3S
-  -- TODO: jumps and double jumps in MaFiA
-  , b1C1H1S
-  , b1C1H1N
-  , b1C1H2C
-  , b1C1H2D
-  , b1C1H2H
-  , b1C1H2S
-  , b1C1H2S2N
-  , b1C1H2S2N3C
-  , b1C1H2S2N3D
-  , b1C1H2S2N3H
-  , b1C1H2S2N3S
-  , b1C1H2N
-  , b1C1H3N
   , tripleFourOneShape  -- For use when defining other bids
 ) where
 

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -551,26 +551,29 @@ b1C1H2S = do
 
 
 b1C1H2S2N :: Action
-b1C1H2S2N :: Action
-    makeAlertableCall (T.Bid 2 T.Notrump) "what is your singleton?"
+b1C1H2S2N = makeAlertableCall (T.Bid 2 T.Notrump) "what is your singleton?"
 
 
 b1C1H2S2N3C :: Action
+b1C1H2S2N3C = do
     suitLength T.Clubs 1
     makeAlertableCall (T.Bid 3 T.Clubs) "singleton club"
 
 
 b1C1H2S2N3D :: Action
+b1C1H2S2N3D = do
     suitLength T.Diamonds 1
     makeAlertableCall (T.Bid 3 T.Clubs) "singleton diamond"
 
 
 b1C1H2S2N3H :: Action
+b1C1H2S2N3H = do
     suitLength T.Hearts 1
     makeAlertableCall (T.Bid 3 T.Clubs) "singleton heart"
 
 
 b1C1H2S2N3S :: Action
+b1C1H2S2N3S = do
     suitLength T.Spades 1
     makeAlertableCall (T.Bid 3 T.Clubs) "singleton spade"
 

--- a/src/Bids/StandardModernPrecision/OneClub.hs
+++ b/src/Bids/StandardModernPrecision/OneClub.hs
@@ -13,6 +13,11 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C2H
   , b1C2Halt
   , b1C2S
+  , b1C2S2N
+  , b1C2S2N3C
+  , b1C2S2N3D
+  , b1C2S2N3H
+  , b1C2S2N3S
   , b1C2Nalt
   , bP1C1H
   , bP1C1S
@@ -54,6 +59,11 @@ module Bids.StandardModernPrecision.OneClub(
   , b1C1H2D
   , b1C1H2H
   , b1C1H2S
+  , b1C1H2S2N
+  , b1C1H2S2N3C
+  , b1C1H2S2N3D
+  , b1C1H2S2N3H
+  , b1C1H2S2N3S
   , b1C1H2N
   , b1C1H3N
   , tripleFourOneShape  -- For use when defining other bids
@@ -160,7 +170,7 @@ b1C1Nalt = do
 b1C2S :: Action
 b1C2S = do
     _slamInterest
-    constrain "triple41" ["shape(", ", 4441 + 4414 + 4144 + 1444)"]
+    tripleFourOneShape
     makeAlertableCall (T.Bid 2 T.Spades) "12+ HCP, any 4441 shape"
 
 
@@ -541,3 +551,44 @@ b1C1H2S :: Action
 b1C1H2S = do
     tripleFourOneShape
     makeAlertableCall (T.Bid 2 T.Spades) "any 4441 hand"
+
+
+b1C1H2S2N :: Action
+b1C1H2S2N :: Action
+    makeAlertableCall (T.Bid 2 T.Notrump) "what is your singleton?"
+
+
+b1C1H2S2N3C :: Action
+    suitLength T.Clubs 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "singleton club"
+
+
+b1C1H2S2N3D :: Action
+    suitLength T.Diamonds 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "singleton diamond"
+
+
+b1C1H2S2N3H :: Action
+    suitLength T.Hearts 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "singleton heart"
+
+
+b1C1H2S2N3S :: Action
+    suitLength T.Spades 1
+    makeAlertableCall (T.Bid 3 T.Clubs) "singleton spade"
+
+
+b1C2S2N :: Action
+b1C2S2N = b1C1H2S2N
+
+b1C2S2N3C :: Action
+b1C2S2N3C = b1C1H2S2N3C
+
+b1C2S2N3D :: Action
+b1C2S2N3D = b1C1H2S2N3D
+
+b1C2S2N3H :: Action
+b1C2S2N3H = b1C1H2S2N3H
+
+b1C2S2N3S :: Action
+b1C2S2N3S = b1C1H2S2N3S

--- a/src/Topics/StandardModernPrecision/TripleFourOne.hs
+++ b/src/Topics/StandardModernPrecision/TripleFourOne.hs
@@ -3,11 +3,10 @@ module Topics.StandardModernPrecision.TripleFourOne(topic) where
 import Bids.StandardModernPrecision.BasicBids(setOpener, oppsPass)
 import Bids.StandardModernPrecision.TwoDiamonds(name44Rkc)
 import qualified Bids.StandardModernPrecision.OneClub as B
-import EDSL(maxSuitLength, pointRange, forEach)
-import Output(Punct(..), (.+))
+import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, wrap, wrapVulNW, wrapVulSE, Situations, makeTopic)
+import Topic(Topic, wrap, Situations, makeTopic)
 
 
 showAny4441 :: Situations
@@ -22,9 +21,9 @@ showAny4441 = let
                 setOpener opener
                 action
           in
-            wrap situation "any" action' bid explanation vul dealer
+            situation "any" action' answer explanation vul dealer
       in
-        wrap inner <~ dealers
+        wrap $ return inner <~ dealers
   in
     wrap $ return sit <~ [ (do B.b1C
                                oppsPass
@@ -37,6 +36,7 @@ showAny4441 = let
                          , (do B.b1C
                                oppsPass
                            , B.bP1C2S, T.North, [T.South, T.East])
+                         ]
                       <~ T.allVulnerabilities
 
 

--- a/src/Topics/StandardModernPrecision/TripleFourOne.hs
+++ b/src/Topics/StandardModernPrecision/TripleFourOne.hs
@@ -13,9 +13,9 @@ showAny4441 :: Situations
 showAny4441 = let
     sit (action, answer, opener, dealers) vul = let
         explanation =
-            "Bidding " .+ T.Bid 2 T.Spades .+ " shows your 4441 shape. " .+
-            "partner will relay to " .+ T.Bid 2 T.Notrump .+ ", prompting " .+
-            "you to bid your singleton, after which " .+ name44Rkc .+ "is on."
+            "Bidding " .+ T.Bid 2 T.Spades .+ " shows our 4441 shape. " .+
+            "Partner will relay to " .+ T.Bid 2 T.Notrump .+ ", prompting " .+
+            "us to bid our singleton, after which " .+ name44Rkc .+ " is on."
         inner dealer = let
             action' = do
                 setOpener opener
@@ -40,9 +40,98 @@ showAny4441 = let
                       <~ T.allVulnerabilities
 
 
+relay :: Situations
+relay = let
+    sit (action, answer, opener, dealers) vul = let
+        explanation =
+            "Partner's " .+ T.Bid 2 T.Spades .+ " showed some 4441 shape. " .+
+            "Relay to " .+ T.Bid 2 T.Notrump .+ ", asking partner to bid " .+
+            "their singleton, after which " .+ name44Rkc .+ " is on."
+        inner dealer = let
+            action' = do
+                setOpener opener
+                action
+          in
+            situation "relay" action' answer explanation vul dealer
+      in
+        wrap $ return inner <~ dealers
+  in
+    wrap $ return sit <~ [ (do B.b1C
+                               oppsPass
+                               B.b1C1H
+                               oppsPass
+                               B.b1C1H2S
+                               oppsPass
+                           , B.b1C1H2S2N, T.North, [T.North, T.West])
+                         , (do B.b1C
+                               oppsPass
+                               B.b1C2S
+                               oppsPass
+                           , B.b1C2S2N, T.South, [T.South, T.East])
+                         , (do B.b1C
+                               oppsPass
+                               B.bP1C2S
+                               oppsPass
+                           , B.b1C2S2N, T.South, [T.North, T.West])
+                         ]
+                      <~ T.allVulnerabilities
+
+
+bidSingleton :: Situations
+bidSingleton = let
+    sit (action, answers, opener, dealers) vul = let
+        explanation =
+            "Our " .+ T.Bid 2 T.Spades .+ " showed some 4441 shape, and " .+
+            "partner has relayed " .+ T.Bid 2 T.Notrump .+ " to ask what " .+
+            "our singleton is. Bid it at the 3 level. " .+ name44Rkc .+
+            " is now on."
+        inner answer dealer = let
+            action' = do
+                setOpener opener
+                action
+          in
+            situation "bsing" action' answer explanation vul dealer
+      in
+        wrap $ return inner <~ answers <~ dealers
+  in
+    wrap $ return sit <~ [ (do B.b1C
+                               oppsPass
+                               B.b1C1H
+                               oppsPass
+                               B.b1C1H2S
+                               oppsPass
+                               B.b1C1H2S2N
+                               oppsPass
+                           , [ B.b1C1H2S2N3C, B.b1C1H2S2N3D
+                             , B.b1C1H2S2N3H, B.b1C1H2S2N3S ]
+                           , T.South, [T.South, T.East])
+                         , (do B.b1C
+                               oppsPass
+                               B.b1C2S
+                               oppsPass
+                               B.b1C2S2N
+                               oppsPass
+                           , [ B.b1C2S2N3C, B.b1C2S2N3D
+                             , B.b1C2S2N3H, B.b1C2S2N3S ]
+                           , T.North, [T.North, T.West])
+                         , (do B.b1C
+                               oppsPass
+                               B.bP1C2S
+                               oppsPass
+                               B.b1C2S2N
+                               oppsPass
+                           , [ B.b1C2S2N3C, B.b1C2S2N3D
+                             , B.b1C2S2N3H, B.b1C2S2N3S ]
+                           , T.North, [T.South, T.East])
+                         ]
+                      <~ T.allVulnerabilities
+
+
 topic :: Topic
 topic = makeTopic description "SMP4441" situations
   where
     description = "SMP 4441 hands"
     situations = wrap [ showAny4441
+                      , relay
+                      , bidSingleton
                       ]

--- a/src/Topics/StandardModernPrecision/TripleFourOne.hs
+++ b/src/Topics/StandardModernPrecision/TripleFourOne.hs
@@ -127,6 +127,55 @@ bidSingleton = let
                       <~ T.allVulnerabilities
 
 
+singletonInPartnerSuit :: Situations
+singletonInPartnerSuit = let
+    sit (action, lastTwoBids, opener, dealers) vul = let
+        explanation =
+            "Partner has bid their primary suit, but we have a 4441 " .+
+            "shape with a singleton in it. Make the cheapest possible " .+
+            "jump-shift to show this. Partner now knows our exact shape, " .+
+            "and can use " .+ name44Rkc .+ " to place the contract."
+        inner (partnerBid, ourBid) dealer = let
+            action' = do
+                setOpener opener
+                _ <- action
+                _ <- partnerBid
+                oppsPass
+          in
+            situation "pdsing" action' ourBid explanation vul dealer
+      in
+        wrap $ return inner <~ lastTwoBids <~ dealers
+  in
+    wrap $ return sit <~ [ (do B.b1C
+                               oppsPass
+                               B.b1C1H
+                               oppsPass
+                           , [ (B.b1C1H1S, B.b1C1H1S3C)
+                             , (B.b1C1H2C, B.b1C1H2C3D)
+                             , (B.b1C1H2D, B.b1C1H2D3H)
+                             , (B.b1C1H2H, B.b1C1H2H3S)
+                             ], T.North, [T.North, T.West])
+                         , (do B.b1C
+                               oppsPass
+                           -- TODO: We're using the standard responses, not the
+                           -- modified ones. Is it worth making a whole separate
+                           -- topic for the modified version? Not sure.
+                           , [ (B.b1C1S, B.b1C1S3C)
+                             , (B.b1C2C, B.b1C2C3D)
+                             , (B.b1C2D, B.b1C2D3H)
+                             , (B.b1C2H, B.b1C2H3S)
+                             ], T.South, [T.South, T.East])
+                         , (do B.b1C
+                               oppsPass
+                           , [ (B.bP1C1H, B.b1C1H2S)
+                             , (B.bP1C1S, B.b1C1S3C)
+                             , (B.bP1C2C, B.b1C2C3D)
+                             , (B.bP1C2D, B.b1C2D3H)
+                             ], T.South, [T.North, T.West])
+                         ]
+                      <~ T.allVulnerabilities
+
+
 topic :: Topic
 topic = makeTopic description "SMP4441" situations
   where
@@ -134,4 +183,5 @@ topic = makeTopic description "SMP4441" situations
     situations = wrap [ showAny4441
                       , relay
                       , bidSingleton
+                      , singletonInPartnerSuit
                       ]

--- a/src/Topics/StandardModernPrecision/TripleFourOne.hs
+++ b/src/Topics/StandardModernPrecision/TripleFourOne.hs
@@ -1,0 +1,48 @@
+module Topics.StandardModernPrecision.TripleFourOne(topic) where
+
+import Bids.StandardModernPrecision.BasicBids(setOpener, oppsPass)
+import Bids.StandardModernPrecision.TwoDiamonds(name44Rkc)
+import qualified Bids.StandardModernPrecision.OneClub as B
+import EDSL(maxSuitLength, pointRange, forEach)
+import Output(Punct(..), (.+))
+import Situation(situation, (<~))
+import qualified Terminology as T
+import Topic(Topic, wrap, wrapVulNW, wrapVulSE, Situations, makeTopic)
+
+
+showAny4441 :: Situations
+showAny4441 = let
+    sit (action, answer, opener, dealers) vul = let
+        explanation =
+            "Bidding " .+ T.Bid 2 T.Spades .+ " shows your 4441 shape. " .+
+            "partner will relay to " .+ T.Bid 2 T.Notrump .+ ", prompting " .+
+            "you to bid your singleton, after which " .+ name44Rkc .+ "is on."
+        inner dealer = let
+            action' = do
+                setOpener opener
+                action
+          in
+            wrap situation "any" action' bid explanation vul dealer
+      in
+        wrap inner <~ dealers
+  in
+    wrap $ return sit <~ [ (do B.b1C
+                               oppsPass
+                               B.b1C1H
+                               oppsPass
+                           , B.b1C1H2S, T.South, [T.South, T.East])
+                         , (do B.b1C
+                               oppsPass
+                           , B.b1C2S, T.North, [T.North, T.West])
+                         , (do B.b1C
+                               oppsPass
+                           , B.bP1C2S, T.North, [T.South, T.East])
+                      <~ T.allVulnerabilities
+
+
+topic :: Topic
+topic = makeTopic description "SMP4441" situations
+  where
+    description = "SMP 4441 hands"
+    situations = wrap [ showAny4441
+                      ]

--- a/src/Topics/StandardModernPrecision/TripleFourOne.hs
+++ b/src/Topics/StandardModernPrecision/TripleFourOne.hs
@@ -130,7 +130,7 @@ bidSingleton = let
 topic :: Topic
 topic = makeTopic description "SMP4441" situations
   where
-    description = "SMP 4441 hands"
+    description = ("SMP 4441 hands in " .+ T.Bid 1 T.Clubs .+ " auctions")
     situations = wrap [ showAny4441
                       , relay
                       , bidSingleton


### PR DESCRIPTION
It's a smaller, more limited topic than I expected, but I think it's separate enough to not be part of a 4C/4D/RKC topic yet. There is a single situation that should be modified if you use the alternative responses (1C-2H-3S should become 1C-1N-3C), which felt big enough to create an Action for it (`b1C1Nalt3C`), but not big enough to create separate `Situations` for the two, let alone separate `Topic`s. If someone really cares, they can edit the source code themselves as relevant. 

I think this is the first time I've had nested `<~`s, where the choices available in a later `<~` depend on the choice made in an earlier one. It looks ugly; is there a prettier way to phrase it? Maybe not...