### PR TITLE
bugfix: don't have a 7-card major when bidding forcing 1N

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -18,7 +18,9 @@ jobs:
       - name: Cache third-party libraries
         uses: actions/cache@v4
         with:
-          key: ${{ matrix.os }}
+          key: ${{ matrix.os }}-
+          restore-keys: |
+            ${{ matrix.os }}-
           path: |
             ~/.stack
             ~/.local/bin

--- a/src/Topics/ForcingOneNotrump.hs
+++ b/src/Topics/ForcingOneNotrump.hs
@@ -153,6 +153,9 @@ limitRaise3 = let
             noInterference suit
             suitLength suit 3
             pointRange 10 12
+            -- Don't be tempted to bid your own ridiculously long suit
+            forEach T.allSuits (`maxSuitLength` 6)
+            forEach T.majorSuits (`maxSuitLength` 5)
         explanation =
             "We've got 3-card support for partner's major, and strength for " .+
             "a limit raise. Start with a forcing " .+ T.Bid 1 T.Notrump .+


### PR DESCRIPTION
Will the Github actions caching work this time? We'll see...