### PR TITLE
Reorganize preempts over notrump

### DIFF
--- a/src/Bids/Cappelletti.hs
+++ b/src/Bids/Cappelletti.hs
@@ -24,13 +24,6 @@ b1N :: Action
 b1N = weak1NT
 
 
--- What's the right minimum strength to bid Cappelletti? It kinda depends on the
--- vulnerability and where in the hand this strength is located. Let's guess 10
--- is a pretty decent minimum, but I'm open to changing it later.
-pointsToCompete :: Action
-pointsToCompete = pointRange 10 40
-
-
 b1NoX :: Action
 b1NoX = do
     pointRange 16 40
@@ -54,7 +47,6 @@ b1NoX = do
 -- the vulnerability.
 b1No2C :: Action
 b1No2C = do
-    pointsToCompete
     forbid b1NoX
     alternatives . map singleSuited $ T.allSuits
     makeAlertableCall (T.Bid 2 T.Clubs)
@@ -67,7 +59,6 @@ b1No2C2D = makeAlertableCall (T.Bid 2 T.Diamonds) "what is your suit?"
 
 b1No2D :: Action
 b1No2D = do
-    pointsToCompete
     forbid b1NoX
     twoSuited T.Hearts T.Spades
     makeAlertableCall (T.Bid 2 T.Diamonds) "both majors"
@@ -75,7 +66,6 @@ b1No2D = do
 
 b1No2H :: Action
 b1No2H = do
-    pointsToCompete
     forbid b1NoX
     alternatives . map (twoSuited T.Hearts) $ T.minorSuits
     makeAlertableCall (T.Bid 2 T.Hearts) "hearts and a minor"
@@ -83,7 +73,6 @@ b1No2H = do
 
 b1No2S :: Action
 b1No2S = do
-    pointsToCompete
     forbid b1NoX
     alternatives . map (twoSuited T.Spades) $ T.minorSuits
     makeAlertableCall (T.Bid 2 T.Spades) "spades and a minor"
@@ -91,7 +80,6 @@ b1No2S = do
 
 b1No2N :: Action
 b1No2N = do
-    pointsToCompete
     forbid b1NoX
     twoSuited T.Clubs T.Diamonds
     makeAlertableCall (T.Bid 2 T.Notrump) "both minors"

--- a/src/Bids/DONT.hs
+++ b/src/Bids/DONT.hs
@@ -8,7 +8,7 @@ module Bids.DONT(
   , b1No2D2H
   , b1No2H
   , b1No2S
-  , b1No3C
+  , b1No3C  -- These next four are all re-exported from NaturalOneNotrumpDefense
   , b1No3D
   , b1No3H
   , b1No3S
@@ -17,10 +17,9 @@ module Bids.DONT(
 
 import Action(Action)
 import Bids.StandardOpenings(b1N)
-import Bids.NaturalOneNotrumpDefense(singleSuited, twoSuited)
+import Bids.NaturalOneNotrumpDefense(singleSuited, twoSuited, b1No3C, b1No3D, b1No3H, b1No3S)
 import EDSL(pointRange, alternatives, makeCall, makeAlertableCall, forEach,
-            longerThan, minSuitLength, maxSuitLength, soundHolding, forbid,
-            forbidAll)
+            longerThan, minSuitLength, forbid)
 import qualified Terminology as T
 
 
@@ -37,7 +36,6 @@ pointsToCompete = pointRange minPointsToCompete 40
 
 b1NoX :: Action
 b1NoX = do
-    shouldntPreempt
     pointsToCompete
     -- If you're single-suited with spades, bid 2S with a minimum, and
     -- double-then-bid with extras.
@@ -96,33 +94,7 @@ b1No2H = do
 b1No2S :: Action
 b1No2S = do
     pointsToCompete
-    shouldntPreempt
     -- If you've got extra strength, double and then bid 2S afterward.
     pointRange 0 (minPointsToCompete + 2)
     singleSuited T.Spades
     makeCall $ T.Bid 2 T.Spades
-
-
-preempt_ :: T.Suit -> Action
-preempt_ suit = do
-    pointsToCompete
-    minSuitLength suit 7
-    soundHolding suit  -- Don't do this with a bad suit, even if you're nonvul.
-    -- Some people are reluctant to pre-empt if they've got a side 4-card major.
-    forEach (filter (/= suit) T.majorSuits) (`maxSuitLength` 3)
-    makeCall $ T.Bid 3 suit
-
-b1No3C :: Action
-b1No3C = preempt_ T.Clubs
-
-b1No3D :: Action
-b1No3D = preempt_ T.Diamonds
-
-b1No3H :: Action
-b1No3H = preempt_ T.Hearts
-
-b1No3S :: Action
-b1No3S = preempt_ T.Spades
-
-shouldntPreempt :: Action
-shouldntPreempt = forbidAll[b1No3C, b1No3D, b1No3H, b1No3S]

--- a/src/Bids/DONT.hs
+++ b/src/Bids/DONT.hs
@@ -17,26 +17,15 @@ module Bids.DONT(
 
 import Action(Action)
 import Bids.StandardOpenings(b1N)
-import Bids.NaturalOneNotrumpDefense(singleSuited, twoSuited, b1No3C, b1No3D, b1No3H, b1No3S)
+import Bids.NaturalOneNotrumpDefense(
+    singleSuited, twoSuited, b1No3C, b1No3D, b1No3H, b1No3S, minPointsToCompete)
 import EDSL(pointRange, alternatives, makeCall, makeAlertableCall, forEach,
             longerThan, minSuitLength, forbid)
 import qualified Terminology as T
 
 
-
--- What's the right minimum strength to bid DONT? It kinda depends on the
--- vulnerability and where in the hand this strength is located. Let's guess 10
--- is a pretty decent minimum, but I'm open to changing it later.
-minPointsToCompete :: Int
-minPointsToCompete = 10
-
-pointsToCompete :: Action
-pointsToCompete = pointRange minPointsToCompete 40
-
-
 b1NoX :: Action
 b1NoX = do
-    pointsToCompete
     -- If you're single-suited with spades, bid 2S with a minimum, and
     -- double-then-bid with extras.
     forbid b1No2S
@@ -50,7 +39,6 @@ b1NoX2C = makeAlertableCall (T.Bid 2 T.Clubs) "pass or correct"
 
 b1No2C :: Action
 b1No2C = do
-    pointsToCompete
     alternatives $ map (twoSuited T.Clubs) [T.Diamonds, T.Hearts, T.Spades]
     makeAlertableCall (T.Bid 2 T.Clubs) "clubs and another suit"
 
@@ -68,7 +56,6 @@ b1No2C2D = do
 
 b1No2D :: Action
 b1No2D = do
-    pointsToCompete
     alternatives $ map (twoSuited T.Diamonds) T.majorSuits
     makeAlertableCall (T.Bid 2 T.Diamonds) "diamonds and a major"
 
@@ -86,14 +73,12 @@ b1No2D2H = do
 
 b1No2H :: Action
 b1No2H = do
-    pointsToCompete
     twoSuited T.Hearts T.Spades
     makeAlertableCall (T.Bid 2 T.Hearts) "both majors"
 
 
 b1No2S :: Action
 b1No2S = do
-    pointsToCompete
     -- If you've got extra strength, double and then bid 2S afterward.
     pointRange 0 (minPointsToCompete + 2)
     singleSuited T.Spades

--- a/src/Bids/Meckwell.hs
+++ b/src/Bids/Meckwell.hs
@@ -22,16 +22,8 @@ import Output ((.+))
 import qualified Terminology as T
 
 
--- What's the right minimum strength to bid Meckwell? It kinda depends on the
--- vulnerability and where in the hand this strength is located. Let's guess 10
--- is a pretty decent minimum, but I'm open to changing it later.
-pointsToCompete :: Action
-pointsToCompete = pointRange 10 40
-
-
 b1NoX :: Action
 b1NoX = do
-    pointsToCompete
     alternatives [ singleSuited T.Clubs
                  , singleSuited T.Diamonds
                  , twoSuited T.Hearts T.Spades
@@ -41,7 +33,6 @@ b1NoX = do
 
 minorAndMajor :: T.Suit -> Action
 minorAndMajor minor = do
-    pointsToCompete
     alternatives [twoSuited minor T.Hearts, twoSuited minor T.Spades]
     makeAlertableCall (T.Bid 2 minor) (show minor .+ " and a major")
 
@@ -54,20 +45,17 @@ b1No2D = minorAndMajor T.Diamonds
 
 b1No2H :: Action
 b1No2H = do
-    pointsToCompete
     singleSuited T.Hearts
     makeCall $ T.Bid 2 T.Hearts
 
 b1No2S :: Action
 b1No2S = do
-    pointsToCompete
     singleSuited T.Spades
     makeCall $ T.Bid 2 T.Spades
 
 
 b1No2N :: Action
 b1No2N = do
-    pointsToCompete
     twoSuited T.Clubs T.Diamonds
     makeAlertableCall (T.Bid 2 T.Notrump) "both minors"
 

--- a/src/Bids/Meckwell.hs
+++ b/src/Bids/Meckwell.hs
@@ -16,8 +16,8 @@ module Bids.Meckwell(
 import Action(Action)
 import Bids.NaturalOneNotrumpDefense(singleSuited, twoSuited)
 import Bids.StandardOpenings(b1N)
-import EDSL(pointRange, minSuitLength, maxSuitLength, makeCall, alternatives,
-            makeAlertableCall, forEach)
+import EDSL(minSuitLength, maxSuitLength, makeCall, makeAlertableCall,
+            alternatives, forEach)
 import Output ((.+))
 import qualified Terminology as T
 

--- a/src/Bids/NaturalOneNotrumpDefense.hs
+++ b/src/Bids/NaturalOneNotrumpDefense.hs
@@ -10,7 +10,6 @@ module Bids.NaturalOneNotrumpDefense(
   -- Export these helpers for other defenses against 1N, too
   , singleSuited
   , twoSuited
-  , shouldntPreempt
 ) where
 
 

--- a/src/Bids/NaturalOneNotrumpDefense.hs
+++ b/src/Bids/NaturalOneNotrumpDefense.hs
@@ -8,6 +8,8 @@ module Bids.NaturalOneNotrumpDefense(
   , b1No3H
   , b1No3S
   -- Export these helpers for other defenses against 1N, too
+  , minPointsToCompete
+  , pointsToCompete
   , singleSuited
   , twoSuited
 ) where
@@ -22,12 +24,16 @@ import qualified Terminology as T
 -- What's the right minimum strength to overcall? It kinda depends on the
 -- vulnerability and where in the hand this strength is located. Let's guess 10
 -- is a pretty decent minimum, but I'm open to changing it later.
+minPointsToCompete :: Int
+minPointsToCompete = 10
+
 pointsToCompete :: Action
-pointsToCompete = pointRange 10 40
+pointsToCompete = pointRange minPointsToCompete 40
 
 
 singleSuited :: T.Suit -> Action
 singleSuited suit = do
+    pointsToCompete
     minSuitLength suit 6
     shouldntPreempt
     soundHolding suit
@@ -42,6 +48,7 @@ singleSuited suit = do
 -- need opinions from someone who has better fundamentals on this stuff.
 twoSuited :: T.Suit -> T.Suit -> Action
 twoSuited a b = do
+    pointsToCompete
     -- With a 6-card suit, you might be better off treating your hand as
     -- single-suited, depending on the suit quality. Rather than program all
     -- that nuance in, we limit ourselves to either 5-4 or 5-5 shapes.


### PR DESCRIPTION
Put them in with the natural bids, and then you can re-export them from other places.