### PR TITLE
add logging to the webserver

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -61,3 +61,4 @@ executables:
     - Spock
     - text
     - wai-middleware-static
+    - wai-extra

--- a/package.yaml
+++ b/package.yaml
@@ -60,5 +60,5 @@ executables:
     - mtl
     - Spock
     - text
-    - wai-middleware-static
     - wai-extra
+    - wai-middleware-static

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -5,6 +5,8 @@ import Control.Monad.Trans(liftIO)
 import Control.Monad.Trans.State.Strict(runStateT)
 import Data.IORef(IORef, newIORef, readIORef, writeIORef)
 import Data.Text(pack)
+-- Take the `Dev` off the end to get more standardized server logs.
+import Network.Wai.Middleware.RequestLogger(logStdoutDev)
 import Network.Wai.Middleware.Static(staticPolicy, addBase)
 import System.Random(StdGen, getStdGen)
 import Web.Spock(SpockM, file, text, get, root, spock, runSpock, json,
@@ -31,7 +33,8 @@ main = do
 
 app :: SpockM () MySession MyAppState ()
 app = do
-    -- NOTE: these first two are relative to the current working directory when
+    middleware logStdoutDev
+    -- NOTE: these next two are relative to the current working directory when
     -- you execute the program! So, you need to run it from the right place.
     middleware (staticPolicy (addBase "static"))
     get root $ file "text/html" "static/index.html"


### PR DESCRIPTION
This was surprisingly easy! I like the colors and whitespace of the development log format, though if I want "proper" server logs I should go with the production option, `logStdout` instead.