### PR TITLE
Better formatting for the debugger

### DIFF
--- a/debugger/Main.hs
+++ b/debugger/Main.hs
@@ -15,7 +15,7 @@ import GHC.Utils.Misc(nTimes)
 import System.Random.Internal(StdGen(..))
 
 import DealerProg(toProgram)
-import Output(toDebugger)
+import Output(toMonospace)
 import Situation(Situation(..))
 import SituationInstance(instantiate)
 import SupportedTopics(getNamedTopic)
@@ -49,7 +49,7 @@ debug topic sitName rng = do
     case maybeSitInst of
         Nothing      -> error "Couldn't instantiate situation!?"
         Just sitInst -> return $ (toProgram . sitDealerProg $ sit) ++ "\n\n" ++
-                                 toDebugger sitInst
+                                 toMonospace sitInst
 
 
 main :: IO ()

--- a/debugger/Main.hs
+++ b/debugger/Main.hs
@@ -15,7 +15,7 @@ import GHC.Utils.Misc(nTimes)
 import System.Random.Internal(StdGen(..))
 
 import DealerProg(toProgram)
-import Output(toLatex)
+import Output(toDebugger)
 import Situation(Situation(..))
 import SituationInstance(instantiate)
 import SupportedTopics(getNamedTopic)
@@ -49,7 +49,7 @@ debug topic sitName rng = do
     case maybeSitInst of
         Nothing      -> error "Couldn't instantiate situation!?"
         Just sitInst -> return $ (toProgram . sitDealerProg $ sit) ++ "\n\n" ++
-                                 toLatex sitInst
+                                 toDebugger sitInst
 
 
 main :: IO ()

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -40,7 +40,7 @@ type Action = State Auction ()
 instance Showable Action where
     toLatex = toLatex . T.removeAlert . extractLastCall
     toHtml = toHtml . T.removeAlert . extractLastCall
-    toDebugger = toDebugger . T.removeAlert . extractLastCall
+    toMonospace = toMonospace . T.removeAlert . extractLastCall
 
 -- AWKWARD TRICK ALERT: Unless you specify the types explicitly, options passed
 -- to `<~` come out as the more general `State Auction a` instead of the more

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -40,6 +40,7 @@ type Action = State Auction ()
 instance Showable Action where
     toLatex = toLatex . T.removeAlert . extractLastCall
     toHtml = toHtml . T.removeAlert . extractLastCall
+    toDebugger = toDebugger . T.removeAlert . extractLastCall
 
 -- AWKWARD TRICK ALERT: Unless you specify the types explicitly, options passed
 -- to `<~` come out as the more general `State Auction a` instead of the more

--- a/src/Action.hs
+++ b/src/Action.hs
@@ -38,8 +38,8 @@ newAuction dealer = (startBidding dealer, mempty)
 type Action = State Auction ()
 
 instance Showable Action where
-    toLatex = toLatex . T.removeAlert . extractLastCall
-    toHtml = toHtml . T.removeAlert . extractLastCall
+    toLatex     = toLatex     . T.removeAlert . extractLastCall
+    toHtml      = toHtml      . T.removeAlert . extractLastCall
     toMonospace = toMonospace . T.removeAlert . extractLastCall
 
 -- AWKWARD TRICK ALERT: Unless you specify the types explicitly, options passed

--- a/src/Bids/Lebensohl.hs
+++ b/src/Bids/Lebensohl.hs
@@ -324,9 +324,8 @@ b1No2S2N3C3S = nameAction "leb_b1No2S2N3C3S" $ cueBid_ T.Spades True
 
 -- Time for the actual lebensohl relays!
 b1N2N3C :: Action
--- This Action adds no constraints to the dealer program, so don't use
--- nameAction here! If you do, it results in syntax errors.
-b1N2N3C = makeAlertableCall (T.Bid 3 T.Clubs) "relay completed"
+b1N2N3C = nameAction "leb_b1N2N3C" $
+    makeAlertableCall (T.Bid 3 T.Clubs) "relay completed"
 
 
 b1No2D2N :: Action

--- a/src/Bids/NaturalOneNotrumpDefense.hs
+++ b/src/Bids/NaturalOneNotrumpDefense.hs
@@ -32,7 +32,7 @@ pointsToCompete = pointRange minPointsToCompete 40
 
 
 singleSuited :: T.Suit -> Action
-singleSuited suit = do
+singleSuited suit = nameAction ("single_suited_" ++ show suit) $ do
     pointsToCompete
     minSuitLength suit 6
     shouldntPreempt
@@ -47,7 +47,7 @@ singleSuited suit = do
 -- convention, and Meckwell has a different answer than DONT or something. I
 -- need opinions from someone who has better fundamentals on this stuff.
 twoSuited :: T.Suit -> T.Suit -> Action
-twoSuited a b = do
+twoSuited a b = nameAction ("two_suited_" ++ show a ++ "_" ++ show b) $ do
     pointsToCompete
     -- With a 6-card suit, you might be better off treating your hand as
     -- single-suited, depending on the suit quality. Rather than program all

--- a/src/Bids/PuppetStayman.hs
+++ b/src/Bids/PuppetStayman.hs
@@ -208,7 +208,7 @@ b2N3C3N4D = nameAction "puppet_b2N3C3N4D" $ do
 
 
 b2N3C3N4D4H :: Action
-b2N3C3N4D4H = makeCall $ T.Bid 4 T.Hearts  -- Remember not to use nameAction!
+b2N3C3N4D4H = nameAction "puppet_b2N3C3N4D4H" $ makeCall $ T.Bid 4 T.Hearts
 
 
 b2N3C3N4H :: Action
@@ -218,4 +218,4 @@ b2N3C3N4H = nameAction "puppet_b2N3C3N4H" $ do
 
 
 b2N3C3N4H4S :: Action
-b2N3C3N4H4S = makeCall $ T.Bid 4 T.Spades  -- Remember not to use nameAction!
+b2N3C3N4H4S = nameAction "puppet_b2N3C3N4H4S" $ makeCall $ T.Bid 4 T.Spades

--- a/src/Bids/StandardModernPrecision/BasicBids.hs
+++ b/src/Bids/StandardModernPrecision/BasicBids.hs
@@ -137,7 +137,12 @@ setOpener opener = do
     (bidding, _) <- get
     if opener == currentBidder bidding
     then _canOpen
-    else forbid _canOpen >> cannotPreempt2H >> makePass >> setOpener opener
+    else cantOpen _canOpen >> setOpener opener
+  where
+    cantOpen openingBid = nameAction "cant_open" $ do
+        forbid openingBid
+        cannotPreempt2H
+        makePass
 
 
 -- unexported helper

--- a/src/Bids/StandardModernPrecision/TwoDiamonds.hs
+++ b/src/Bids/StandardModernPrecision/TwoDiamonds.hs
@@ -46,7 +46,7 @@ name44Rkc = T.Bid 4 T.Clubs .+ "/" .+ T.Bid 4 T.Diamonds .+ "/RKC"
 
 
 noDirectOvercall :: Action
-noDirectOvercall = do
+noDirectOvercall = nameAction "no_overcall" $ do
     cannotPreempt
     -- Either you don't have enough strength or enough shape to overcall
     alternatives [ pointRange 0 10

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -49,7 +49,9 @@ invert (DealerProg defns reqs) =
 
 nameAll :: CondName -> DealerProg -> DealerProg
 nameAll name (DealerProg defns reqs) =
-    addNewReq name (join " && " . reverse $ reqs) (DealerProg defns mempty)
+    if (length reqs > 0)
+    then addNewReq name (join " && " . reverse $ reqs) (DealerProg defns mempty)
+    else DealerProg defns reqs  -- Unchanged
 
 
 toProgram :: DealerProg -> String

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -19,7 +19,7 @@ import Data.Function((&))
 
 data OutputType = LaTeX
                 | Html
-                | Debugger
+                | Monospace
 
 
 newtype Description = Description [OutputType -> String]
@@ -41,17 +41,17 @@ class Showable a where
     -- default "implementation" for those types, and clean this up eventually.
     toHtml :: a -> String
     toHtml _ = undefined
-    toDebugger :: a -> String
+    toMonospace :: a -> String
 
 instance Showable String where
-    toLatex    = id
-    toHtml     = id
-    toDebugger = id
+    toLatex     = id
+    toHtml      = id
+    toMonospace = id
 
 instance Showable Description where
-    toLatex     (Description d) = concatMap (LaTeX    &) $ d
-    toHtml      (Description d) = concatMap (Html     &) $ d
-    toDebugger  (Description d) = concatMap (Debugger &) $ d
+    toLatex     (Description d) = concatMap (LaTeX     &) $ d
+    toHtml      (Description d) = concatMap (Html      &) $ d
+    toMonospace (Description d) = concatMap (Monospace &) $ d
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Description
@@ -61,9 +61,9 @@ a .+ b = toDescription a <> toDescription b
 toDescription :: Showable a => a -> Description
 toDescription a = Description [flip output a]
   where
-    output LaTeX    = toLatex
-    output Html     = toHtml
-    output Debugger = toDebugger
+    output LaTeX     = toLatex
+    output Html      = toHtml
+    output Monospace = toMonospace
 
 
 data Punct = NDash
@@ -83,8 +83,8 @@ instance Showable Punct where
     toHtml OpenQuote = "&#x201C;"
     toHtml CloseQuote = "&#x201D;"
     toHtml EAcute = "&eacute;"
-    toDebugger NDash = "-"
-    toDebugger MDash = "---"
-    toDebugger OpenQuote = "\""
-    toDebugger CloseQuote = "\""
-    toDebugger EAcute = "e"
+    toMonospace NDash = "-"
+    toMonospace MDash = "---"
+    toMonospace OpenQuote = "\""
+    toMonospace CloseQuote = "\""
+    toMonospace EAcute = "e"

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -19,6 +19,7 @@ import Data.Function((&))
 
 data OutputType = LaTeX
                 | Html
+                | Debugger
 
 
 newtype Description = Description [OutputType -> String]
@@ -40,14 +41,17 @@ class Showable a where
     -- default "implementation" for those types, and clean this up eventually.
     toHtml :: a -> String
     toHtml _ = undefined
+    toDebugger :: a -> String
 
 instance Showable String where
-    toLatex = id
-    toHtml = id
+    toLatex    = id
+    toHtml     = id
+    toDebugger = id
 
 instance Showable Description where
-    toLatex (Description d) = concatMap (LaTeX &) $ d
-    toHtml  (Description d) = concatMap (Html  &) $ d
+    toLatex     (Description d) = concatMap (LaTeX    &) $ d
+    toHtml      (Description d) = concatMap (Html     &) $ d
+    toDebugger  (Description d) = concatMap (Debugger &) $ d
 
 
 (.+) :: (Showable a, Showable b) => a -> b -> Description
@@ -57,8 +61,9 @@ a .+ b = toDescription a <> toDescription b
 toDescription :: Showable a => a -> Description
 toDescription a = Description [flip output a]
   where
-    output LaTeX = toLatex
-    output Html = toHtml
+    output LaTeX    = toLatex
+    output Html     = toHtml
+    output Debugger = toDebugger
 
 
 data Punct = NDash
@@ -78,3 +83,8 @@ instance Showable Punct where
     toHtml OpenQuote = "&#x201C;"
     toHtml CloseQuote = "&#x201D;"
     toHtml EAcute = "&eacute;"
+    toDebugger NDash = "--"
+    toDebugger MDash = "---"
+    toDebugger OpenQuote = "\""
+    toDebugger CloseQuote = "\""
+    toDebugger EAcute = "e"

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -83,7 +83,7 @@ instance Showable Punct where
     toHtml OpenQuote = "&#x201C;"
     toHtml CloseQuote = "&#x201D;"
     toHtml EAcute = "&eacute;"
-    toDebugger NDash = "--"
+    toDebugger NDash = "-"
     toDebugger MDash = "---"
     toDebugger OpenQuote = "\""
     toDebugger CloseQuote = "\""

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -27,7 +27,7 @@ instance Semigroup Description where
     (Description as) <> (Description bs) = Description (as ++ bs)
 
 instance Monoid Description where
-    mempty = Description [const ""]
+    mempty = Description []
 
 instance ToJSON Description where
     toJSON (Description d) = toJSON . concatMap (Html  &) $ d

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -24,16 +24,23 @@ data SituationInstance =
 
 
 instance Showable SituationInstance where
-    toLatex (SituationInstance b c s d ds) =
+    toLatex (SituationInstance bidding answer explanation deal debugString) =
         "\\problem{%\n" ++
-            join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, toLatex s, ds] ++
+            join "%\n}{%\n" [ toLatex deal
+                            , toLatex bidding
+                            , toLatex answer
+                            , toLatex explanation
+                            , debugString
+                            ] ++
             "%\n}"
     toHtml _ = "todo"
-    toMonospace (SituationInstance b c s d _) =
-        join "\n" [ toMonospace d
-                  , toMonospace b
-                  , "Answer: " ++ toMonospace c
-                  , toMonospace s
+    toMonospace (SituationInstance bidding call solution deal _) =
+        join "\n" [ toMonospace deal
+                  , ""
+                  , toMonospace bidding
+                  , ""
+                  , "Answer: " ++ toMonospace call
+                  , toMonospace solution
                   ]
 
 instance ToJSON SituationInstance where

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -29,6 +29,12 @@ instance Showable SituationInstance where
             join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, toLatex s, ds] ++
             "%\n}"
     toHtml _ = "todo"
+    toDebugger (SituationInstance b c s d _) =
+        join "\n" [ toDebugger d
+                  , toDebugger b
+                  , "answer: " ++ toDebugger c
+                  , toDebugger s
+                  ]
 
 instance ToJSON SituationInstance where
     toJSON (SituationInstance b c s d ds) = toJSON . fromList $

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -29,11 +29,11 @@ instance Showable SituationInstance where
             join "%\n}{%\n" [toLatex d, toLatex b, toLatex c, toLatex s, ds] ++
             "%\n}"
     toHtml _ = "todo"
-    toDebugger (SituationInstance b c s d _) =
-        join "\n" [ toDebugger d
-                  , toDebugger b
-                  , "Answer: " ++ toDebugger c
-                  , toDebugger s
+    toMonospace (SituationInstance b c s d _) =
+        join "\n" [ toMonospace d
+                  , toMonospace b
+                  , "Answer: " ++ toMonospace c
+                  , toMonospace s
                   ]
 
 instance ToJSON SituationInstance where

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -32,7 +32,7 @@ instance Showable SituationInstance where
     toDebugger (SituationInstance b c s d _) =
         join "\n" [ toDebugger d
                   , toDebugger b
-                  , "answer: " ++ toDebugger c
+                  , "Answer: " ++ toDebugger c
                   , toDebugger s
                   ]
 

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -88,8 +88,9 @@ instance Showable Bidding where
             (rowBids, nextFootnote') =
                 foldr foldFormatMaybeBid ([], nextFootnote) row
           in
-            ((join " " rowBids) : results, nextFootnote')
-        formatAuction = join "\n" . fst . foldr foldFormatBidRow ([], 1 :: Int)
+            ((join " " . reverse $ rowBids) : results, nextFootnote')
+        formatAuction = join "\n" . reverse . fst .
+                        foldr foldFormatBidRow ([], 1 :: Int)
         foldFormatAlert (T.CompleteCall _ m) (alerts, nextFootnote) = case m of
             Nothing -> (alerts, nextFootnote)
             Just a  ->
@@ -163,7 +164,7 @@ instance Showable Deal where
         formatEW = zipWith (\a b -> take 20 (a ++ replicate 20 ' ') ++ b)
         header = ["Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v, ""]
       in
-        join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW es ws ++ [""] ++
+        join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW ws es ++ [""] ++
                     formatNS ss
 
 instance ToJSON Deal where

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -162,10 +162,10 @@ instance Showable Deal where
         indent = replicate 8 ' '
         formatNS = map (indent ++)
         formatEW = zipWith (\a b -> take 20 (a ++ replicate 20 ' ') ++ b)
-        header = ["Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v, ""]
+        footer = "Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v
       in
-        join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW ws es ++ [""] ++
-                    formatNS ss
+        join "\n" $ formatNS ns ++ [""] ++ formatEW ws es ++ [""] ++
+                    formatNS ss ++ ["", footer]
 
 instance ToJSON Deal where
     toJSON (Deal d v n e s w) = toJSON . fromList $

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -33,8 +33,7 @@ instance Showable Hand where
     toMonospace (Hand s h d c) =
         join "\n" $ zipWith formatSuit "SHDC" [s, h, d, c]
       where
-        formatSuit name holding = (name : ": ") ++ spaceCards holding
-        spaceCards = replace "." (toMonospace NDash) . replace "T" "10"
+        formatSuit name holding = (name : ": ") ++ (replace "T" "10" holding)
 
 instance ToJSON Hand where
     toJSON (Hand s h d c) = toJSON . fmap formatHolding . fromList $

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -73,7 +73,7 @@ instance Showable Bidding where
         finish T.North = newRow
         finish _       = "&"
     toMonospace (Bidding _ b) =
-        header ++ formatAuction b ++ "??\n\n" ++ formatAlerts b ++ "\n"
+        header ++ formatAuction b ++ "??\n\n" ++ formatAlerts b
       where
         header = " West North  East South\n"
         formatAuction = join "\n" . reverse . fst . foldl formatAuction' ([], 1) . reverse . map catMaybes
@@ -168,7 +168,7 @@ instance Showable Deal where
         header = ["Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v, ""]
       in
         join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW es ws ++ [""] ++
-                    formatNS ss ++ [""]
+                    formatNS ss
 
 instance ToJSON Deal where
     toJSON (Deal d v n e s w) = toJSON . fromList $

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -98,7 +98,7 @@ instance Showable Bidding where
         formatAlerts = join "\n" . reverse . fst .
                        foldr foldFormatAlert ([], 1 :: Int) . catMaybes . concat
       in
-        header ++ formatAuction auction ++ "??\n\n" ++ formatAlerts auction
+        header ++ formatAuction auction ++ " ??\n\n" ++ formatAlerts auction
 
 
 -- TODO: make good support for alerts in here. Currently they're all displayed

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -73,8 +73,10 @@ instance Showable Bidding where
             toLatex c ++ "\\" ++ alertMacro ++ "{" ++ toLatex a ++ "}"
         finish T.North = newRow
         finish _       = "&"
-    toDebugger (Bidding _ b) = formatAuction b ++ "??\n\n" ++ formatAlerts b
+    toDebugger (Bidding _ b) =
+        header ++ formatAuction b ++ "??\n\n" ++ formatAlerts b ++ "\n"
       where
+        header = " West North  East South\n"
         formatAuction = join "\n" . reverse . fst . foldl formatAuction' ([], 1) . reverse . map catMaybes
         formatAuction' :: ([String], Int) -> [T.CompleteCall] -> ([String], Int)
         formatAuction' (outputRows, nextFootnote) row = let
@@ -161,13 +163,13 @@ instance Showable Deal where
         es = lines . toDebugger $ e
         ss = lines . toDebugger $ s
         ws = lines . toDebugger $ w
-        indent = "        "
+        indent = replicate 8 ' '
         formatNS = map (indent ++)
-        -- TODO: get the East hand indented properly
-        formatEW = zipWith (\a b -> a ++ indent ++ b)
-        header = ["Dealer: " ++ toDebugger d ++ ", Vul: " ++ toDebugger v]
+        formatEW = zipWith (\a b -> take 20 (a ++ replicate 20 ' ') ++ b)
+        header = ["Dealer: " ++ toDebugger d ++ ", Vul: " ++ toDebugger v, ""]
       in
-        join "\n" $ header ++ formatNS ns ++ formatEW es ws ++ formatNS ss
+        join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW es ws ++ [""] ++
+                    formatNS ss ++ [""]
 
 instance ToJSON Deal where
     toJSON (Deal d v n e s w) = toJSON . fromList $

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -30,11 +30,11 @@ instance Showable Hand where
                         replace "T" "10" .
                         replace " " "\\,") [s, h, d, c])
         ++ "}"
-    toDebugger (Hand s h d c) =
+    toMonospace (Hand s h d c) =
         join "\n" $ zipWith formatSuit "SHDC" [s, h, d, c]
       where
         formatSuit name holding = (name : ": ") ++ spaceCards holding
-        spaceCards = replace "." (toDebugger NDash) . replace "T" "10"
+        spaceCards = replace "." (toMonospace NDash) . replace "T" "10"
 
 instance ToJSON Hand where
     toJSON (Hand s h d c) = toJSON . fmap formatHolding . fromList $
@@ -73,7 +73,7 @@ instance Showable Bidding where
             toLatex c ++ "\\" ++ alertMacro ++ "{" ++ toLatex a ++ "}"
         finish T.North = newRow
         finish _       = "&"
-    toDebugger (Bidding _ b) =
+    toMonospace (Bidding _ b) =
         header ++ formatAuction b ++ "??\n\n" ++ formatAlerts b ++ "\n"
       where
         header = " West North  East South\n"
@@ -81,8 +81,8 @@ instance Showable Bidding where
         formatAuction' :: ([String], Int) -> [T.CompleteCall] -> ([String], Int)
         formatAuction' (outputRows, nextFootnote) row = let
             formatBid (rowSoFar, nextFootnote') (T.CompleteCall c a) = case a of
-                Nothing -> (rowSoFar ++ toDebugger c ++ "    ", nextFootnote')
-                Just _  -> (rowSoFar ++ toDebugger c ++
+                Nothing -> (rowSoFar ++ toMonospace c ++ "    ", nextFootnote')
+                Just _  -> (rowSoFar ++ toMonospace c ++
                                 "[" ++ show nextFootnote' ++ "] "
                            , nextFootnote' + 1
                            )
@@ -104,7 +104,7 @@ instance Showable Bidding where
             Just a -> ((formatAlert' nextFootnote a) : alertsSoFar, nextFootnote + 1)
         formatAlert' :: Int -> Description -> String
         formatAlert' nextFootnote a =
-            "[" ++ show nextFootnote++ "]: " ++ toDebugger a
+            "[" ++ show nextFootnote++ "]: " ++ toMonospace a
 
 -- TODO: make good support for alerts in here. Currently they're all displayed
 -- all the time.
@@ -158,15 +158,15 @@ instance Showable Deal where
       where
         capitalize (h:t) = toUpper h : t
         capitalize _     = error "Attempt to capitalize empty direction!?"
-    toDebugger (Deal d v n e s w) = let
-        ns = lines . toDebugger $ n
-        es = lines . toDebugger $ e
-        ss = lines . toDebugger $ s
-        ws = lines . toDebugger $ w
+    toMonospace (Deal d v n e s w) = let
+        ns = lines . toMonospace $ n
+        es = lines . toMonospace $ e
+        ss = lines . toMonospace $ s
+        ws = lines . toMonospace $ w
         indent = replicate 8 ' '
         formatNS = map (indent ++)
         formatEW = zipWith (\a b -> take 20 (a ++ replicate 20 ' ') ++ b)
-        header = ["Dealer: " ++ toDebugger d ++ ", Vul: " ++ toDebugger v, ""]
+        header = ["Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v, ""]
       in
         join "\n" $ header ++ formatNS ns ++ [""] ++ formatEW es ws ++ [""] ++
                     formatNS ss ++ [""]

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -156,7 +156,18 @@ instance Showable Deal where
       where
         capitalize (h:t) = toUpper h : t
         capitalize _     = error "Attempt to capitalize empty direction!?"
-    toDebugger _ = error "TODO"
+    toDebugger (Deal d v n e s w) = let
+        ns = lines . toDebugger $ n
+        es = lines . toDebugger $ e
+        ss = lines . toDebugger $ s
+        ws = lines . toDebugger $ w
+        indent = "        "
+        formatNS = map (indent ++)
+        -- TODO: get the East hand indented properly
+        formatEW = zipWith (\a b -> a ++ indent ++ b)
+        header = ["Dealer: " ++ toDebugger d ++ ", Vul: " ++ toDebugger v]
+      in
+        join "\n" $ header ++ formatNS ns ++ formatEW es ws ++ formatNS ss
 
 instance ToJSON Deal where
     toJSON (Deal d v n e s w) = toJSON . fromList $

--- a/src/Terminology.hs
+++ b/src/Terminology.hs
@@ -35,10 +35,10 @@ instance Showable Direction where
     toHtml East  = "E"
     toHtml South = "S"
     toHtml West  = "W"
-    toDebugger North = "N"
-    toDebugger East  = "E"
-    toDebugger South = "S"
-    toDebugger West  = "W"
+    toMonospace North = "N"
+    toMonospace East  = "E"
+    toMonospace South = "S"
+    toMonospace West  = "W"
 
 -- We keep these lowercase because that's the format that dealer wants. You'll
 -- have to upper-case them yourself to print them out.
@@ -74,11 +74,11 @@ instance Showable Suit where
     toHtml Hearts   = "<span style='color: red'>&hearts;</span>"
     toHtml Spades   = "&spades;"
     toHtml Notrump  = "<span style='font-variant: small-caps'>nt</span>"
-    toDebugger Clubs    = "C"
-    toDebugger Diamonds = "D"
-    toDebugger Hearts   = "H"
-    toDebugger Spades   = "S"
-    toDebugger Notrump  = "N"
+    toMonospace Clubs    = "C"
+    toMonospace Diamonds = "D"
+    toMonospace Hearts   = "H"
+    toMonospace Spades   = "S"
+    toMonospace Notrump  = "N"
 
 instance Show Suit where
     show Clubs    = "clubs"
@@ -129,10 +129,10 @@ instance Showable Call where
     toHtml Double    = "Dbl"
     toHtml Redouble  = "Rdb"
     toHtml (Bid l s) = show l ++ toHtml s
-    toDebugger Pass      = " P"
-    toDebugger Double    = " X"
-    toDebugger Redouble  = "XX"
-    toDebugger (Bid l s) = show l ++ toDebugger s
+    toMonospace Pass      = " P"
+    toMonospace Double    = " X"
+    toMonospace Redouble  = "XX"
+    toMonospace (Bid l s) = show l ++ toMonospace s
 
 instance SuitBid Call where
     suitBid (Bid _ s) = s
@@ -151,8 +151,8 @@ instance Showable CompleteCall where
         toLatex c ++ maybe "" (\x -> " (" ++ toLatex x ++ ")") a
     toHtml (CompleteCall c a) =
         toHtml c ++ maybe "" (\x -> " (" ++ toHtml x ++ ")") a
-    toDebugger (CompleteCall c a) =
-        toDebugger c ++ maybe "" (\x -> " (" ++ toDebugger x ++ ")") a
+    toMonospace (CompleteCall c a) =
+        toMonospace c ++ maybe "" (\x -> " (" ++ toMonospace x ++ ")") a
 
 instance ToJSON CompleteCall where
     toJSON (CompleteCall c a) = let
@@ -180,10 +180,10 @@ instance Showable Vulnerability where
     toHtml EW   = "E/W"
     toHtml Both = "Both"
     toHtml None = "None"
-    toDebugger NS   = "N/S"
-    toDebugger EW   = "E/W"
-    toDebugger Both = "Both"
-    toDebugger None = "None"
+    toMonospace NS   = "N/S"
+    toMonospace EW   = "E/W"
+    toMonospace Both = "Both"
+    toMonospace None = "None"
 
 allVulnerabilities :: [Vulnerability]
 allVulnerabilities = [NS, EW, Both, None]

--- a/src/Terminology.hs
+++ b/src/Terminology.hs
@@ -21,7 +21,7 @@ import Data.Aeson(ToJSON, toJSON, object, (.=))
 import Data.Aeson.Key(fromString)
 import Data.List(singleton)
 
-import Output(Showable, toLatex, toHtml, Description)
+import Output(Showable(..), Description)
 
 
 data Direction = North | East | South | West deriving Eq
@@ -35,6 +35,10 @@ instance Showable Direction where
     toHtml East  = "E"
     toHtml South = "S"
     toHtml West  = "W"
+    toDebugger North = "N"
+    toDebugger East  = "E"
+    toDebugger South = "S"
+    toDebugger West  = "W"
 
 -- We keep these lowercase because that's the format that dealer wants. You'll
 -- have to upper-case them yourself to print them out.
@@ -60,16 +64,21 @@ next West  = North
 data Suit = Clubs | Diamonds | Hearts | Spades | Notrump deriving Eq
 
 instance Showable Suit where
-    toLatex Clubs     = "\\c{}"
-    toLatex Diamonds  = "\\d{}"
-    toLatex Hearts    = "\\h{}"
-    toLatex Spades    = "\\s{}"
-    toLatex Notrump   = "\\nt{}"
-    toHtml Clubs     = "&clubs;"
-    toHtml Diamonds  = "<span style='color: red'>&diams;</span>"
-    toHtml Hearts    = "<span style='color: red'>&hearts;</span>"
-    toHtml Spades    = "&spades;"
-    toHtml Notrump   = "<span style='font-variant: small-caps'>nt</span>"
+    toLatex Clubs    = "\\c{}"
+    toLatex Diamonds = "\\d{}"
+    toLatex Hearts   = "\\h{}"
+    toLatex Spades   = "\\s{}"
+    toLatex Notrump  = "\\nt{}"
+    toHtml Clubs    = "&clubs;"
+    toHtml Diamonds = "<span style='color: red'>&diams;</span>"
+    toHtml Hearts   = "<span style='color: red'>&hearts;</span>"
+    toHtml Spades   = "&spades;"
+    toHtml Notrump  = "<span style='font-variant: small-caps'>nt</span>"
+    toDebugger Clubs    = "C"
+    toDebugger Diamonds = "D"
+    toDebugger Hearts   = "H"
+    toDebugger Spades   = "S"
+    toDebugger Notrump  = "N"
 
 instance Show Suit where
     show Clubs    = "clubs"
@@ -120,6 +129,10 @@ instance Showable Call where
     toHtml Double    = "Dbl"
     toHtml Redouble  = "Rdb"
     toHtml (Bid l s) = show l ++ toHtml s
+    toDebugger Pass      = " P"
+    toDebugger Double    = " X"
+    toDebugger Redouble  = "XX"
+    toDebugger (Bid l s) = show l ++ toDebugger s
 
 instance SuitBid Call where
     suitBid (Bid _ s) = s
@@ -138,6 +151,8 @@ instance Showable CompleteCall where
         toLatex c ++ maybe "" (\x -> " (" ++ toLatex x ++ ")") a
     toHtml (CompleteCall c a) =
         toHtml c ++ maybe "" (\x -> " (" ++ toHtml x ++ ")") a
+    toDebugger (CompleteCall c a) =
+        toDebugger c ++ maybe "" (\x -> " (" ++ toDebugger x ++ ")") a
 
 instance ToJSON CompleteCall where
     toJSON (CompleteCall c a) = let
@@ -165,6 +180,10 @@ instance Showable Vulnerability where
     toHtml EW   = "E/W"
     toHtml Both = "Both"
     toHtml None = "None"
+    toDebugger NS   = "N/S"
+    toDebugger EW   = "E/W"
+    toDebugger Both = "Both"
+    toDebugger None = "None"
 
 allVulnerabilities :: [Vulnerability]
 allVulnerabilities = [NS, EW, Both, None]

--- a/src/Topics/Cappelletti.hs
+++ b/src/Topics/Cappelletti.hs
@@ -3,7 +3,8 @@ module Topics.Cappelletti(topic) where
 import Action(Action)
 import qualified Bids.Cappelletti as B
 import CommonBids(setOpener)
-import EDSL(pointRange, forEach, minSuitLength, maxSuitLength, makePass)
+import EDSL(pointRange, forEach, minSuitLength, maxSuitLength, makePass,
+            nameAction)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
@@ -11,7 +12,7 @@ import Topic(Topic, wrap, Situations, makeTopic)
 
 
 responderCannotBid :: Action
-responderCannotBid = do
+responderCannotBid = nameAction "responder_pass" $ do
     pointRange 0 7                           -- No jumping to 3N, etc.
     forEach T.majorSuits (`maxSuitLength` 4) -- No transfers
     minSuitLength T.Clubs 2                  -- Avoid Garbage Stayman

--- a/src/Topics/DONT.hs
+++ b/src/Topics/DONT.hs
@@ -3,7 +3,8 @@ module Topics.DONT(topic) where
 import Action(Action)
 import qualified Bids.DONT as B
 import CommonBids(setOpener)
-import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach)
+import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach,
+            nameAction)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
@@ -11,7 +12,7 @@ import Topic(Topic, wrap, Situations, makeTopic)
 
 
 responderCannotBid :: Action
-responderCannotBid = do
+responderCannotBid = nameAction "responder_pass" $ do
     pointRange 0 7                           -- No jumping to 3N, etc.
     forEach T.majorSuits (`maxSuitLength` 4) -- No transfers
     minSuitLength T.Clubs 2                  -- Avoid Garbage Stayman

--- a/src/Topics/Meckwell.hs
+++ b/src/Topics/Meckwell.hs
@@ -3,7 +3,8 @@ module Topics.Meckwell(topic) where
 import Action(Action)
 import qualified Bids.Meckwell as B
 import CommonBids(setOpener)
-import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach)
+import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach,
+            nameAction)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
@@ -11,7 +12,7 @@ import Topic(Topic, wrap, Situations, makeTopic)
 
 
 responderCannotBid :: Action
-responderCannotBid = do
+responderCannotBid = nameAction "responder_pass" $ do
     pointRange 0 7                           -- No jumping to 3N, etc.
     forEach T.majorSuits (`maxSuitLength` 4) -- No transfers
     minSuitLength T.Clubs 2                  -- Avoid Garbage Stayman

--- a/src/Topics/Woolsey.hs
+++ b/src/Topics/Woolsey.hs
@@ -3,7 +3,8 @@ module Topics.Woolsey(topic) where
 import Action(Action)
 import qualified Bids.Woolsey as W
 import CommonBids(setOpener, strong1NT, weak1NT)
-import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach, forbid)
+import EDSL(pointRange, minSuitLength, maxSuitLength, makePass, forEach, forbid,
+            nameAction)
 import Output((.+), Punct(..))
 import Situation(situation, (<~))
 import qualified Terminology as T
@@ -12,7 +13,7 @@ import Topic(Topic, wrap, Situations, makeTopic)
 
 -- TODO: maybe remove this
 responderCannotBid :: Action
-responderCannotBid = do
+responderCannotBid = nameAction "responder_pass" $ do
     pointRange 0 7                           -- No jumping to 3N, etc.
     forEach T.majorSuits (`maxSuitLength` 4) -- No transfers
     minSuitLength T.Clubs 2                  -- Avoid Garbage Stayman


### PR DESCRIPTION
This is a follow-up to #119, with better formatting. The `Showable` typeclass now contains a function `toMonospace` which is intended to be used when debugging. I've only tried one example so far, but I think it looks way better.