### PR TITLE
Assert unique Topic IDs at compile time

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ dependencies:
 - MissingH
 - process
 - random
+- template-haskell
 - transformers
 
 ghc-options:

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -16,7 +16,7 @@ import Web.Spock(SpockM, file, text, get, root, spock, runSpock, json,
 import Web.Spock.Config(PoolOrConn(PCNoDatabase), defaultSpockCfg)
 
 import ProblemSet(generate)
-import SupportedTopics(assertUniqueTopicIndices, topicNames, findTopics)
+import SupportedTopics(topicNames, findTopics)
 
 
 data MySession = EmptySession
@@ -25,7 +25,6 @@ data MyAppState = IoRng (IORef StdGen)
 
 main :: IO ()
 main = do
-    assertUniqueTopicIndices
     rng <- getStdGen
     ref <- newIORef rng
     spockCfg <- defaultSpockCfg EmptySession PCNoDatabase (IoRng ref)

--- a/src/CompileTime.hs
+++ b/src/CompileTime.hs
@@ -1,0 +1,32 @@
+-- We use Template Haskell to check at compile time whether every Topic ID is unique. This function
+-- must be compiled before SupportedTopics.hs, which is why it's a separate file.
+{-# LANGUAGE TemplateHaskell #-}
+
+module CompileTime(compileTimeAssertUniqueTopicIDs) where
+
+import Control.Arrow((&&&))
+import Control.Monad(unless)
+import Data.List(sort)
+import qualified Language.Haskell.TH.Syntax as THS
+
+
+duplicatesOf_ :: [Int] -> [Int]
+duplicatesOf_ = map fst . filter (uncurry (==)) . uncurry zip . (init &&& tail) . sort
+
+compileTimeAssertUniqueTopicIDs :: THS.Q THS.Exp -> THS.Q THS.Exp
+compileTimeAssertUniqueTopicIDs qexp = let
+    getId :: THS.Exp -> Int
+    getId (THS.TupE [Just (THS.LitE (THS.IntegerL i)), _, _]) = fromInteger i
+    getId e = error $ "Invalid element in list: " ++ show e
+  in do
+    expr <- qexp
+    case expr of
+        THS.ListE items -> do
+            let duplicates = duplicatesOf_ . map getId $ items
+            unless (null duplicates) $
+                fail $ "Duplicate Topic IDs found: " ++ show duplicates
+            qexp
+        _ -> fail "Expected a list of items"
+
+
+-- TODO: use `unlines` instead of `join "\n"`

--- a/src/CompileTime.hs
+++ b/src/CompileTime.hs
@@ -27,6 +27,3 @@ compileTimeAssertUniqueTopicIDs qexp = let
                 fail $ "Duplicate Topic IDs found: " ++ show duplicates
             qexp
         _ -> fail "Expected a list of items"
-
-
--- TODO: use `unlines` instead of `join "\n"`

--- a/src/DealerProg.hs
+++ b/src/DealerProg.hs
@@ -55,7 +55,7 @@ nameAll name (DealerProg defns reqs) =
 
 
 toProgram :: DealerProg -> String
-toProgram (DealerProg defns conds) = join "\n" $
+toProgram (DealerProg defns conds) = unlines $
     -- This used to generate 1 million boards, but some situations are extremely
     -- rare (e.g., North opens a Precision 1D with 5 hearts and South responds
     -- 2N: occurs less than twice in a million deals), and if you run the dealer
@@ -102,7 +102,7 @@ eval dir vul deal seed = let
     toSuits output@(_:s:h:d:c:_)
      | length output == 11 = Just $ map splitSuit [s, h, d, c]
     -- If that didn't work, we have totally misunderstood something.
-    toSuits problem     = error $ join "\n"
+    toSuits problem     = error $ unlines
         ("Unexpected output from dealer invocation:":prog:"Output was:":problem)
 
     splitSuit :: String -> [String]

--- a/src/ProblemSet.hs
+++ b/src/ProblemSet.hs
@@ -46,7 +46,7 @@ outputLatex :: Int -> [Topic] -> String -> StateT StdGen IO String
 outputLatex numHands topics filename = do
     problems <- generate numHands topics
     let topicNames = join ", " . map (toLatex . topicName) $ topics
-        problemSet = join "\n" . map toLatex $ problems
+        problemSet = unlines . map toLatex $ problems
     template <- lift $ readFile "template.tex"
     let doc = replace "%<TOPICS>" topicNames .
               replace "%<PROBLEMS>" problemSet $ template

--- a/src/SituationInstance.hs
+++ b/src/SituationInstance.hs
@@ -35,13 +35,13 @@ instance Showable SituationInstance where
             "%\n}"
     toHtml _ = "todo"
     toMonospace (SituationInstance bidding call solution deal _) =
-        join "\n" [ toMonospace deal
-                  , ""
-                  , toMonospace bidding
-                  , ""
-                  , "Answer: " ++ toMonospace call
-                  , toMonospace solution
-                  ]
+        unlines [ toMonospace deal
+                , ""
+                , toMonospace bidding
+                , ""
+                , "Answer: " ++ toMonospace call
+                , toMonospace solution
+                ]
 
 instance ToJSON SituationInstance where
     toJSON (SituationInstance b c s d ds) = toJSON . fromList $

--- a/src/Structures.hs
+++ b/src/Structures.hs
@@ -31,7 +31,7 @@ instance Showable Hand where
                         replace " " "\\,") [s, h, d, c])
         ++ "}"
     toMonospace (Hand s h d c) =
-        join "\n" $ zipWith formatSuit "SHDC" [s, h, d, c]
+        unlines $ zipWith formatSuit "SHDC" [s, h, d, c]
       where
         formatSuit name holding = (name : ": ") ++ (replace "T" "10" holding)
 
@@ -89,14 +89,14 @@ instance Showable Bidding where
                 foldr foldFormatMaybeBid ([], nextFootnote) row
           in
             ((join " " . reverse $ rowBids) : results, nextFootnote')
-        formatAuction = join "\n" . reverse . fst .
+        formatAuction = unlines . reverse . fst .
                         foldr foldFormatBidRow ([], 1 :: Int)
         foldFormatAlert (T.CompleteCall _ m) (alerts, nextFootnote) = case m of
             Nothing -> (alerts, nextFootnote)
             Just a  ->
                 ( ("[" ++ show nextFootnote ++ "]: " ++ toMonospace a) : alerts
                 , nextFootnote + 1)
-        formatAlerts = join "\n" . reverse . fst .
+        formatAlerts = unlines . reverse . fst .
                        foldr foldFormatAlert ([], 1 :: Int) . catMaybes . concat
       in
         header ++ formatAuction auction ++ " ??\n\n" ++ formatAlerts auction
@@ -164,8 +164,8 @@ instance Showable Deal where
         formatEW = zipWith (\a b -> take 20 (a ++ replicate 20 ' ') ++ b)
         footer = "Dealer: " ++ toMonospace d ++ ", Vul: " ++ toMonospace v
       in
-        join "\n" $ formatNS ns ++ [""] ++ formatEW ws es ++ [""] ++
-                    formatNS ss ++ ["", footer]
+        unlines $ formatNS ns ++ [""] ++ formatEW ws es ++ [""] ++
+                  formatNS ss ++ ["", footer]
 
 instance ToJSON Deal where
     toJSON (Deal d v n e s w) = toJSON . fromList $

--- a/src/SupportedTopics.hs
+++ b/src/SupportedTopics.hs
@@ -3,16 +3,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module SupportedTopics(
-    assertUniqueTopicIndices
-  , topicNames
+    topicNames
   , findTopics
   , getNamedTopic
 ) where
 
-import Control.Monad(when)
 import Data.Aeson(Value, object, (.=))
 import Data.Aeson.Key(fromString)
-import Data.Containers.ListUtils(nubOrd)
 import Data.Either.Extra(maybeToEither, mapLeft)
 import Data.List(find)
 import Data.List.Utils(join, split)
@@ -58,7 +55,9 @@ import qualified Topics.StandardModernPrecision.TripleFourOne as TripleFourOne
 -- The list is the order to display topics on the website. The int is a unique
 -- ID for the topic when requesting a situation. That way, you can add new
 -- topics to the middle of the list without messing up anyone using the website.
--- The boolean is whether this topic should be selected by default.
+-- The boolean is whether this topic should be selected by default. If topic
+-- indices aren't unique, we're gonna have really subtle bugs that will be hard
+-- to figure out.
 topicList :: [(Int, Bool, Topic)]
 topicList = $(compileTimeAssertUniqueTopicIDs [|
             [ (10, True,  StandardOpeners.topic)
@@ -88,17 +87,6 @@ topicList = $(compileTimeAssertUniqueTopicIDs [|
             --, (70, False, Lampe.topic)
             , (56, False, TwoDiamondOpeners.topic)
             ] |])
-
-
--- If topic indices aren't unique, we're gonna have really subtle bugs that will
--- be hard to figure out.
--- TODO: consider making this a compile-time assertion instead, possibly via
--- https://stackoverflow.com/a/6654903
-assertUniqueTopicIndices :: IO ()
-assertUniqueTopicIndices = let
-    indices = map fst3 topicList
-  in
-    when (indices /= nubOrd indices) (error "duplicate topic indices!?")
 
 
 topics :: Map Int Topic

--- a/src/SupportedTopics.hs
+++ b/src/SupportedTopics.hs
@@ -1,3 +1,7 @@
+-- We use a compile-time assertion that every supported Topic has a unique ID. Doing things at
+-- compile time requires using Template Haskell.
+{-# LANGUAGE TemplateHaskell #-}
+
 module SupportedTopics(
     assertUniqueTopicIndices
   , topicNames
@@ -16,6 +20,7 @@ import Data.Map(Map, fromList, (!?))
 import Data.Tuple.Extra((&&&))
 import Data.Tuple.Utils(fst3, thd3)
 
+import CompileTime(compileTimeAssertUniqueTopicIDs)
 import Output(toHtml)
 import Topic(Topic, refName, topicName)
 
@@ -55,7 +60,8 @@ import qualified Topics.StandardModernPrecision.TripleFourOne as TripleFourOne
 -- topics to the middle of the list without messing up anyone using the website.
 -- The boolean is whether this topic should be selected by default.
 topicList :: [(Int, Bool, Topic)]
-topicList = [ (10, True,  StandardOpeners.topic)
+topicList = $(compileTimeAssertUniqueTopicIDs [|
+            [ (10, True,  StandardOpeners.topic)
             , (11, True,  MajorSuitRaises.topic)
             , (26, True,  Overcalls.topic)
             , (24, True,  TakeoutDoubles.topic)
@@ -81,7 +87,7 @@ topicList = [ (10, True,  StandardOpeners.topic)
             , (55, False, Smp1DResponses.topic)
             --, (70, False, Lampe.topic)
             , (56, False, TwoDiamondOpeners.topic)
-            ]
+            ] |])
 
 
 -- If topic indices aren't unique, we're gonna have really subtle bugs that will


### PR DESCRIPTION
Thanks to ChatGPT for help with Template Haskell. ChatGPT gave code that worked but was needlessly complicated; I've changed approximately every line it gave me. but it did let me skip learning how Template Haskell works.

While I was in here, I also changed every use of `join "\n"` to `unlines`.