### PR TITLE
Topic for common 3-level bids over 1N

### DIFF
--- a/src/Bids/OneNotrump.hs
+++ b/src/Bids/OneNotrump.hs
@@ -52,6 +52,7 @@ module Bids.OneNotrump(
   , b1N3D
   , b1N3H
   , b1N3S
+  , b1N3N
   , b1N4D
   , b1N4D4H
   , b1N4H
@@ -585,3 +586,15 @@ b1N3S = nameAction "b1N3S" $ do
     forEach T.minorSuits (`minSuitLength` 4)
     forEach T.minorSuits (`maxSuitLength` 5)
     makeAlertableCall (T.Bid 3 T.Spades) "splinter: 13(54) shape, GF"
+
+
+b1N3N :: Action
+b1N3N = nameAction "b1N3N" $ do
+    gameNoSlam
+    balancedHand
+    forbidAll [b1N2C, b1N2D, b1N2D]
+    -- If you use puppet Stayman over 1N, prefer that except when responder is
+    -- 4333 with a 4-card minor (because you're unlikely to ruff anything in the
+    -- hand with short trump).
+    --flathand
+    makeCall $ T.Bid 3 T.Spades

--- a/src/Bids/OneNotrump.hs
+++ b/src/Bids/OneNotrump.hs
@@ -49,6 +49,9 @@ module Bids.OneNotrump(
   , b1N2H2S3S
   , b1N2H2S4S
   , b1N2H3S
+  , b1N3D
+  , b1N3H
+  , b1N3S
   , b1N4D
   , b1N4D4H
   , b1N4H
@@ -549,3 +552,36 @@ b1N2H2S3S = nameAction "b1N2H2S3S" $ do
     -- hand you might upgrade to game-forcing anyway. Avoid these situations.
     forEach [T.Clubs, T.Diamonds, T.Hearts] (`maxSuitLength` 3)
     makeCall $ T.Bid 3 T.Spades
+
+
+-- Common 3-level responses
+
+-- TODO: some folks play 3C is (low-info) Puppet Stayman, others play it's 5-5
+-- in the minors and invitational. Define these things eventually.
+
+
+b1N3D :: Action
+b1N3D = nameAction "b1N3D" $ do
+    gameForcing
+    forEach T.minorSuits (`minSuitLength` 5)
+    makeAlertableCall (T.Bid 3 T.Diamonds) "at least 5-5 in the minors, GF"
+
+
+b1N3H :: Action
+b1N3H = nameAction "b1N3H" $ do
+    gameForcing
+    suitLength T.Hearts 1
+    suitLength T.Spades 3
+    forEach T.minorSuits (`minSuitLength` 4)
+    forEach T.minorSuits (`maxSuitLength` 5)
+    makeAlertableCall (T.Bid 3 T.Hearts) "splinter: 31(54) shape, GF"
+
+
+b1N3S :: Action
+b1N3S = nameAction "b1N3S" $ do
+    gameForcing
+    suitLength T.Spades 1
+    suitLength T.Hearts 3
+    forEach T.minorSuits (`minSuitLength` 4)
+    forEach T.minorSuits (`maxSuitLength` 5)
+    makeAlertableCall (T.Bid 3 T.Spades) "splinter: 13(54) shape, GF"

--- a/src/Bids/OneNotrump.hs
+++ b/src/Bids/OneNotrump.hs
@@ -593,8 +593,11 @@ b1N3N = nameAction "b1N3N" $ do
     gameNoSlam
     balancedHand
     forbidAll [b1N2C, b1N2D, b1N2D]
+    -- If you're 4-3 in the majors, you might prefer to bid Stayman or puppet
+    -- Stayman. Until puppet Stayman is implemented, forbid that here anyway.
+    forEach T.majorSuits (`maxSuitLength` 3)
     -- If you use puppet Stayman over 1N, prefer that except when responder is
     -- 4333 with a 4-card minor (because you're unlikely to ruff anything in the
     -- hand with short trump).
     --flathand
-    makeCall $ T.Bid 3 T.Spades
+    makeCall $ T.Bid 3 T.Notrump

--- a/src/SupportedTopics.hs
+++ b/src/SupportedTopics.hs
@@ -33,6 +33,7 @@ import qualified Topics.PuppetStayman as PuppetStayman
 import qualified Topics.MuppetStayman as MuppetStayman
 import qualified Topics.TexasTransfers as TexasTransfers
 import qualified Topics.Smolen as Smolen
+import qualified Topics.ThreeLevelResponsesTo1N as B1N3X
 import qualified Topics.Meckwell as Meckwell
 import qualified Topics.DONT as DONT
 import qualified Topics.Cappelletti as Cappelletti
@@ -70,6 +71,7 @@ topicList = $(compileTimeAssertUniqueTopicIDs [|
     , (14, True,  Stayman.topic)
     , (15, False, TexasTransfers.topic)
     , (23, False, Smolen.topic)
+    , (28, False, B1N3X.topic)
     , (22, False, PuppetStayman.topic)
     , (27, False, MuppetStayman.topic)
     , (16, False, Meckwell.topic)

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -64,7 +64,7 @@ signoff = let
 
 
 topic :: Topic
-topic = makeTopic ("Common 3-level responses to" .+ B.b1N) "1N3X" situations
+topic = makeTopic ("Common 3-level responses to " .+ B.b1N) "1N3X" situations
   where
     situations = wrap [ splinter
                       , bothMinors

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -1,0 +1,51 @@
+module Topics.ThreeLevelResponsesTo1N(topic) where
+
+import qualified Bids.OneNotrump as B
+import CommonBids(setOpener)
+import EDSL(alternatives)
+import Output(Punct(..), (.+))
+import Situation(situation, (<~))
+import qualified Terminology as T
+import Topic(Topic, stdWrap, stdWrapSE, wrap, wrapDlr, Situations, makeTopic)
+
+
+splinter :: Situations
+splinter = let
+    sit bid = let
+        action = do
+            setOpener T.North
+            B.b1N
+            B.noInterference
+        explanation =
+            "Partner opened a strong " .+ B.b1N .+ ". With game-forcing " .+
+            "strength, 5-4 in the minors and 3-1 in the majors, make a " .+
+            "splinter bid. Partner will place the contract from here."
+      in situation "splnt" action bid explanation
+  in
+    wrapDlr $ return sit <~ [B.b1N3H, B.b1N3S]
+
+bothMinors :: Situations
+bothMinors = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b1N
+            B.noInterference
+        explanation =
+            "Partner opened a strong " .+ B.b1N .+ ". With game-forcing " .+
+            "strength and at least 5-5 in the minors, jump in diamonds. " .+
+            "Opener can place the strain from here, either by signing off " .+
+            "in " .+ B.b1N3N .+ ", or setting trump at the 4 level. We'll " .+
+            "usually just raise a 4-level bid to game in the minor, but " .+
+            "could explore slam with sufficient strength."
+      in situation "m55" action B.b1N3D explanation
+  in
+    wrapDlr $ return sit
+
+
+topic :: Topic
+topic = makeTopic ("Common 3-level responses to" .+ B.b1N) "1N3X" situations
+  where
+    situations = wrap [ splinter
+                      , bothMinors
+                      ]

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -18,7 +18,9 @@ splinter = let
         explanation =
             "Partner opened a strong " .+ B.b1N .+ ". With game-forcing " .+
             "strength, 5-4 in the minors and 3-1 in the majors, make a " .+
-            "splinter bid. Partner will place the contract from here."
+            "splinter bid. Partner will place the contract from here. In " .+
+            "rare circumstances, we can investigate slam after partner has " .+
+            "set the trump suit (if any)."
       in situation "splnt" action bid explanation
   in
     wrapDlr $ return sit <~ [B.b1N3H, B.b1N3S]

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -2,11 +2,10 @@ module Topics.ThreeLevelResponsesTo1N(topic) where
 
 import qualified Bids.OneNotrump as B
 import CommonBids(setOpener)
-import EDSL(alternatives)
-import Output(Punct(..), (.+))
+import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, stdWrap, stdWrapSE, wrap, wrapDlr, Situations, makeTopic)
+import Topic(Topic, stdWrap, wrap, wrapDlr, Situations, makeTopic)
 
 
 splinter :: Situations
@@ -40,7 +39,7 @@ bothMinors = let
             "could explore slam with sufficient strength."
       in situation "m55" action B.b1N3D explanation
   in
-    wrapDlr $ return sit
+    stdWrap sit
 
 
 topic :: Topic

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -23,6 +23,7 @@ splinter = let
   in
     wrapDlr $ return sit <~ [B.b1N3H, B.b1N3S]
 
+
 bothMinors :: Situations
 bothMinors = let
     sit = let
@@ -42,9 +43,26 @@ bothMinors = let
     stdWrap sit
 
 
+signoff :: Situations
+signoff = let
+    sit = let
+        action = do
+            setOpener T.North
+            B.b1N
+            B.noInterference
+        explanation =
+            "Partner opened a strong " .+ B.b1N .+ ". With game-forcing " .+
+            "strength with no slam interest, a balanced hand, and no " .+
+            "interest in the majors, just sign off in game."
+      in situation "1N3N" action B.b1N3N explanation
+  in
+    stdWrap sit
+
+
 topic :: Topic
 topic = makeTopic ("Common 3-level responses to" .+ B.b1N) "1N3X" situations
   where
     situations = wrap [ splinter
                       , bothMinors
+                      , signoff
                       ]

--- a/src/Topics/ThreeLevelResponsesTo1N.hs
+++ b/src/Topics/ThreeLevelResponsesTo1N.hs
@@ -5,7 +5,7 @@ import CommonBids(setOpener)
 import Output((.+))
 import Situation(situation, (<~))
 import qualified Terminology as T
-import Topic(Topic, stdWrap, wrap, wrapDlr, Situations, makeTopic)
+import Topic(Topic, stdWrap, wrap, wrapDlr, stdWrapNW, Situations, makeTopic)
 
 
 splinter :: Situations
@@ -42,7 +42,9 @@ bothMinors = let
             "could explore slam with sufficient strength."
       in situation "m55" action B.b1N3D explanation
   in
-    stdWrap sit
+    -- If you had 10+ HCPs and 5-5 in the minors, you would have opened the
+    -- bidding. So, make sure partner bids before you do.
+    stdWrapNW sit
 
 
 signoff :: Situations


### PR DESCRIPTION
Closes #158 

When it's time to make low-info puppet Stayman bids, consider restricting 1N-3N auctions to ones that can't use that (only 33(43) shape? Even (32)44 would go through low-info puppet, I think). 

Should I define a bid where 1N-3C shows 5-5 in the minors with less than GF strength? Not sure, skipping for now.