### PR TITLE
Use local storage to remember which topics have been selected

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -40,10 +40,10 @@ getTopics().then(topics => {
         checkbox.id    = tag_name;
         checkbox.name  = "topics";
         checkbox.value = topic.index;
-		if (saved_checkboxes === null) {
-			checkbox.checked = topic.select_by_default;
-		} else {
+		if (saved_checkboxes) {
 			checkbox.checked = saved_checkboxes.includes(topic.index);
+		} else {
+			checkbox.checked = topic.select_by_default;
 		}
 
         const topic_name = document.createElement("span");


### PR DESCRIPTION
fixes #162 

This way, you can refresh the tab without going back to the default topics.